### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.2.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 license = "MIT"
@@ -26,17 +26,17 @@ categories = ["finance", "encoding", "network-programming"]
 
 [workspace.dependencies]
 # Internal crates
-ironsbe = { path = "ironsbe", version = "0.1.2" }
-ironsbe-core = { path = "ironsbe-core", version = "0.1.2" }
-ironsbe-schema = { path = "ironsbe-schema", version = "0.1.2" }
-ironsbe-codegen = { path = "ironsbe-codegen", version = "0.1.2" }
-ironsbe-derive = { path = "ironsbe-derive", version = "0.1.2" }
-ironsbe-channel = { path = "ironsbe-channel", version = "0.1.2" }
-ironsbe-transport = { path = "ironsbe-transport", version = "0.1.2" }
-ironsbe-server = { path = "ironsbe-server", version = "0.1.2" }
-ironsbe-client = { path = "ironsbe-client", version = "0.1.2" }
-ironsbe-marketdata = { path = "ironsbe-marketdata", version = "0.1.2" }
-ironsbe-bench = { path = "ironsbe-bench", version = "0.1.2" }
+ironsbe = { path = "ironsbe", version = "0.2.0" }
+ironsbe-core = { path = "ironsbe-core", version = "0.2.0" }
+ironsbe-schema = { path = "ironsbe-schema", version = "0.2.0" }
+ironsbe-codegen = { path = "ironsbe-codegen", version = "0.2.0" }
+ironsbe-derive = { path = "ironsbe-derive", version = "0.2.0" }
+ironsbe-channel = { path = "ironsbe-channel", version = "0.2.0" }
+ironsbe-transport = { path = "ironsbe-transport", version = "0.2.0" }
+ironsbe-server = { path = "ironsbe-server", version = "0.2.0" }
+ironsbe-client = { path = "ironsbe-client", version = "0.2.0" }
+ironsbe-marketdata = { path = "ironsbe-marketdata", version = "0.2.0" }
+ironsbe-bench = { path = "ironsbe-bench", version = "0.2.0" }
 
 # External dependencies - Latest stable versions as of Jan 2025
 thiserror = "2.0"


### PR DESCRIPTION
## Summary
Bump version from 0.1.2 to 0.2.0 across all workspace crates.

## Changes
- Updated workspace version to 0.2.0
- Updated all 11 internal crate dependency versions

## Breaking Changes
API changes from codegen refactoring (PRs #11, #15) require major version bump per semver.