### PR TITLE
fix(lint): improve to_snake_case + fix clippy + bump to 0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 license = "MIT"
@@ -26,17 +26,17 @@ categories = ["finance", "encoding", "network-programming"]
 
 [workspace.dependencies]
 # Internal crates
-ironsbe = { path = "ironsbe", version = "0.2.0" }
-ironsbe-core = { path = "ironsbe-core", version = "0.2.0" }
-ironsbe-schema = { path = "ironsbe-schema", version = "0.2.0" }
+ironsbe = { path = "ironsbe", version = "0.2.1" }
+ironsbe-core = { path = "ironsbe-core", version = "0.2.1" }
+ironsbe-schema = { path = "ironsbe-schema", version = "0.2.1" }
 ironsbe-codegen = { path = "ironsbe-codegen", version = "0.2.1" }
-ironsbe-derive = { path = "ironsbe-derive", version = "0.2.0" }
-ironsbe-channel = { path = "ironsbe-channel", version = "0.2.0" }
-ironsbe-transport = { path = "ironsbe-transport", version = "0.2.0" }
-ironsbe-server = { path = "ironsbe-server", version = "0.2.0" }
-ironsbe-client = { path = "ironsbe-client", version = "0.2.0" }
-ironsbe-marketdata = { path = "ironsbe-marketdata", version = "0.2.0" }
-ironsbe-bench = { path = "ironsbe-bench", version = "0.2.0" }
+ironsbe-derive = { path = "ironsbe-derive", version = "0.2.1" }
+ironsbe-channel = { path = "ironsbe-channel", version = "0.2.1" }
+ironsbe-transport = { path = "ironsbe-transport", version = "0.2.1" }
+ironsbe-server = { path = "ironsbe-server", version = "0.2.1" }
+ironsbe-client = { path = "ironsbe-client", version = "0.2.1" }
+ironsbe-marketdata = { path = "ironsbe-marketdata", version = "0.2.1" }
+ironsbe-bench = { path = "ironsbe-bench", version = "0.2.1" }
 
 # External dependencies - Latest stable versions as of Jan 2025
 thiserror = "2.0"

--- a/ironsbe-schema/src/ir.rs
+++ b/ironsbe-schema/src/ir.rs
@@ -486,7 +486,7 @@ pub fn to_snake_case(s: &str) -> String {
 
             if i > 0 {
                 let prev = chars[i - 1];
-                let next_is_lower = chars.get(i + 1).map_or(false, |n| n.is_lowercase());
+                let next_is_lower = chars.get(i + 1).is_some_and(|n| n.is_lowercase());
 
                 // Word boundary: lowercase->uppercase OR acronym end (XXXy -> XXX_Y)
                 let boundary = (prev_lower && is_upper)


### PR DESCRIPTION
Cherry-picks the improved `to_snake_case` from PR #8 (by @DevineLiu), fixes the `clippy::unnecessary_map_or` lint that was causing CI to fail, and bumps the workspace version to 0.2.1.

### Changes
- **`ironsbe-schema/src/ir.rs`**: Improved `to_snake_case` that correctly handles acronyms (e.g. `MDEntryPx` → `md_entry_px`). Fixed `map_or(false, ...)` → `is_some_and(...)`.
- **`Cargo.toml`**: Workspace version 0.2.0 → 0.2.1, all dependency refs updated.

Supersedes #8 (lint-fixed version). All tests pass, zero clippy warnings.