### PR TITLE
M2 #26: LocalServer/LocalClient for uring backend + examples + round-trip bench

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ rtrb = "0.3"
 lru = "0.16"
 memmap2 = "0.9"
 criterion = { version = "0.8", features = ["html_reports"] }
+hdrhistogram = "7"
 
 [profile.release]
 opt-level = 3

--- a/docs/transport-backends.md
+++ b/docs/transport-backends.md
@@ -205,13 +205,72 @@ operation.
 The io_uring backend uses the same 4-byte little-endian length-prefix
 framing as `tcp-tokio`, so the two backends are wire-compatible.
 
-### Scope
+### Server integration: `LocalServer` and `LocalClient`
 
-This module ships the trait-level integration only.  Server integration
-(`ironsbe-server` running on a `tokio-uring` runtime), examples, and
-benchmark numbers are tracked in the follow-up issue.  Buffer pooling,
-registered buffers, registered fds and `IORING_OP_SEND_ZC` are also
-deferred to the same follow-up.
+The high-level `Server` / `Client` types in `ironsbe-server` /
+`ironsbe-client` are generic over the multi-threaded `Transport` family
+and so cannot drive a `LocalTransport` backend directly.  Instead, the
+crates expose **parallel `LocalServer` / `LocalClient` types** generic
+over `LocalTransport`.  They share `MessageHandler`, `ServerHandle`,
+`ClientHandle`, the command/event enums and most of the session loop
+with the multi-threaded versions; the differences are:
+
+- Trait bound is `T: LocalTransport` (no `Send + Sync`).
+- Per-session tasks are spawned via `tokio::task::spawn_local` rather
+  than `tokio::spawn`, so they can hold `!Send` connections.
+- `run()` must be polled inside a Tokio `LocalSet`.
+  `tokio_uring::start` installs one for free; for plain `tokio` you can
+  use `tokio::task::LocalSet::run_until`.
+
+```rust
+use ironsbe_server::{LocalServerBuilder, MessageHandler};
+use ironsbe_transport::tcp_uring::UringTcpTransport;
+
+fn main() -> Result<(), ironsbe_server::ServerError> {
+    let (mut server, _handle) =
+        LocalServerBuilder::<MyHandler, UringTcpTransport>::new()
+            .bind("127.0.0.1:9000".parse().expect("addr"))
+            .handler(MyHandler)
+            .build();
+    tokio_uring::start(async move { server.run().await })
+}
+```
+
+The same shape applies to `LocalClientBuilder` / `LocalClient`.  Working
+end-to-end examples live in `ironsbe/examples/uring_server.rs` and
+`ironsbe/examples/uring_client.rs`.
+
+#### Multi-worker scaling
+
+This first iteration runs a single uring reactor on the calling thread.
+Spreading load across cores via `SO_REUSEPORT` + one worker per core is
+a deliberate follow-up: the bench numbers below will tell us whether
+single-worker latency is already good enough or whether the multi-worker
+work is justified.
+
+### Benchmarks
+
+The `transport_round_trip` bench in `ironsbe-bench` measures the
+per-message latency of a 64-byte SBE message round-trip against both
+backends.  Run with:
+
+```sh
+# tcp-tokio only:
+cargo bench -p ironsbe-bench --bench transport_round_trip
+
+# both backends (Linux ≥ 5.10):
+cargo bench -p ironsbe-bench --bench transport_round_trip --features tcp-uring
+```
+
+Numbers (TBD — pending hardware run):
+
+| Backend     | p50 | p99 | p99.9 | Throughput |
+|-------------|-----|-----|-------|------------|
+| `tcp-tokio` | TBD | TBD | TBD   | TBD        |
+| `tcp-uring` | TBD | TBD | TBD   | TBD        |
+
+These will be filled in after running the bench on a Linux ≥ 5.10
+machine and updated in this doc plus the PR description.
 
 ### Building
 

--- a/ironsbe-bench/Cargo.toml
+++ b/ironsbe-bench/Cargo.toml
@@ -24,6 +24,7 @@ ironsbe-transport = { workspace = true, features = ["tcp-tokio"] }
 criterion = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 bytes = { workspace = true }
+hdrhistogram = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 tokio-uring = { workspace = true }

--- a/ironsbe-bench/Cargo.toml
+++ b/ironsbe-bench/Cargo.toml
@@ -10,12 +10,23 @@ homepage.workspace = true
 keywords = ["benchmark", "performance", "sbe"]
 categories = ["development-tools::profiling"]
 
+[features]
+default = []
+# Linux-only io_uring backend.  Forwards to the matching feature in
+# ironsbe-transport so the transport_round_trip bench can include the
+# uring path.
+tcp-uring = ["ironsbe-transport/tcp-uring"]
+
 [dependencies]
 ironsbe-core = { workspace = true }
 ironsbe-channel = { workspace = true }
-ironsbe-transport = { workspace = true }
+ironsbe-transport = { workspace = true, features = ["tcp-tokio"] }
 criterion = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+bytes = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+tokio-uring = { workspace = true }
 
 [[bench]]
 name = "encoding"
@@ -27,4 +38,8 @@ harness = false
 
 [[bench]]
 name = "performance"
+harness = false
+
+[[bench]]
+name = "transport_round_trip"
 harness = false

--- a/ironsbe-bench/benches/transport_round_trip.rs
+++ b/ironsbe-bench/benches/transport_round_trip.rs
@@ -143,7 +143,6 @@ mod uring {
 
     pub(super) enum UringCommand {
         Send(Vec<u8>),
-        Shutdown,
     }
 
     pub(super) enum UringReply {
@@ -185,15 +184,10 @@ mod uring {
                         UringTcpTransport::connect_with(UringClientConfig::new(listen_addr))
                             .await
                             .expect("uring connect");
-                    while let Ok(cmd) = command_rx.recv() {
-                        match cmd {
-                            UringCommand::Send(payload) => {
-                                client.send(&payload).await.expect("uring send");
-                                let echo = client.recv().await.expect("uring recv").expect("frame");
-                                let _ = reply_tx.send(UringReply::Echo(echo.to_vec()));
-                            }
-                            UringCommand::Shutdown => break,
-                        }
+                    while let Ok(UringCommand::Send(payload)) = command_rx.recv() {
+                        client.send(&payload).await.expect("uring send");
+                        let echo = client.recv().await.expect("uring recv").expect("frame");
+                        let _ = reply_tx.send(UringReply::Echo(echo.to_vec()));
                     }
                 });
             });

--- a/ironsbe-bench/benches/transport_round_trip.rs
+++ b/ironsbe-bench/benches/transport_round_trip.rs
@@ -1,0 +1,253 @@
+//! End-to-end transport round-trip benchmark.
+//!
+//! Measures the time to send a small SBE message from the client to the
+//! server and receive an echo back.  Compares the multi-threaded
+//! `tcp-tokio` backend against the Linux-only `tcp-uring` backend (when
+//! the `tcp-uring` feature is enabled).
+//!
+//! Run with:
+//!
+//! ```sh
+//! # tcp-tokio only:
+//! cargo bench -p ironsbe-bench --bench transport_round_trip
+//!
+//! # both backends (Linux >= 5.10):
+//! cargo bench -p ironsbe-bench --bench transport_round_trip --features tcp-uring
+//! ```
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use ironsbe_transport::tcp::{TcpClientConfig, TcpServerConfig, TokioTcpTransport};
+use ironsbe_transport::traits::{Connection, Transport};
+use std::hint::black_box;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::OnceLock;
+use std::thread;
+use std::time::Duration;
+use tokio::runtime::Runtime;
+use tokio::sync::oneshot;
+
+const PAYLOAD_LEN: usize = 64;
+const ITERATIONS_PER_BATCH: usize = 32;
+
+/// Builds a deterministic payload of the given length so the benchmark
+/// is reproducible across runs.
+fn make_payload() -> Vec<u8> {
+    (0..PAYLOAD_LEN).map(|i| (i & 0xff) as u8).collect()
+}
+
+// =====================================================================
+// tcp-tokio path
+// =====================================================================
+
+struct TokioFixture {
+    runtime: Arc<Runtime>,
+    server_addr: SocketAddr,
+    _server_thread: thread::JoinHandle<()>,
+}
+
+fn tokio_fixture() -> &'static TokioFixture {
+    static FIXTURE: OnceLock<TokioFixture> = OnceLock::new();
+    FIXTURE.get_or_init(|| {
+        let runtime = Arc::new(
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(2)
+                .enable_all()
+                .build()
+                .expect("build tokio runtime"),
+        );
+        let bind_addr: SocketAddr = "127.0.0.1:0".parse().expect("addr");
+        let (addr_tx, addr_rx) = oneshot::channel();
+        let rt_clone = Arc::clone(&runtime);
+        let server_thread = thread::spawn(move || {
+            rt_clone.block_on(async move {
+                let mut listener = TokioTcpTransport::bind_with(TcpServerConfig::new(bind_addr))
+                    .await
+                    .expect("bind");
+                let listen_addr = listener.local_addr().expect("local_addr");
+                let _ = addr_tx.send(listen_addr);
+                loop {
+                    let conn = listener.accept().await.expect("accept");
+                    tokio::spawn(echo_loop_tokio(conn));
+                }
+            });
+        });
+        let server_addr = runtime.block_on(addr_rx).expect("addr");
+        TokioFixture {
+            runtime,
+            server_addr,
+            _server_thread: server_thread,
+        }
+    })
+}
+
+async fn echo_loop_tokio<C: Connection>(mut conn: C) {
+    while let Ok(Some(msg)) = conn.recv().await {
+        if conn.send(&msg).await.is_err() {
+            break;
+        }
+    }
+}
+
+fn bench_tcp_tokio_round_trip(c: &mut Criterion) {
+    let fixture = tokio_fixture();
+    let runtime = Arc::clone(&fixture.runtime);
+    let server_addr = fixture.server_addr;
+
+    let mut group = c.benchmark_group("transport_round_trip/tcp_tokio");
+    group.measurement_time(Duration::from_secs(8));
+    group.sample_size(50);
+    group.bench_function("payload_64B", |b| {
+        // Connect once, reuse the connection across iterations to keep
+        // the bench measuring round-trip latency, not connect cost.
+        let payload = make_payload();
+        let mut client = runtime.block_on(async {
+            TokioTcpTransport::connect_with(TcpClientConfig::new(server_addr))
+                .await
+                .expect("connect")
+        });
+        b.iter(|| {
+            runtime.block_on(async {
+                for _ in 0..ITERATIONS_PER_BATCH {
+                    client.send(&payload).await.expect("send");
+                    let echo = client.recv().await.expect("recv").expect("frame");
+                    black_box(echo);
+                }
+            });
+        });
+    });
+    group.finish();
+}
+
+// =====================================================================
+// tcp-uring path (Linux only)
+// =====================================================================
+
+#[cfg(all(feature = "tcp-uring", target_os = "linux"))]
+mod uring {
+    use super::*;
+    use ironsbe_transport::tcp_uring::{UringClientConfig, UringServerConfig, UringTcpTransport};
+    use ironsbe_transport::traits::{LocalConnection, LocalListener, LocalTransport};
+    use std::sync::mpsc as std_mpsc;
+
+    pub(super) struct UringFixture {
+        pub(super) server_addr: SocketAddr,
+        pub(super) command_tx: std_mpsc::SyncSender<UringCommand>,
+        pub(super) reply_rx: std_mpsc::Receiver<UringReply>,
+        _runtime_thread: thread::JoinHandle<()>,
+    }
+
+    pub(super) enum UringCommand {
+        Send(Vec<u8>),
+        Shutdown,
+    }
+
+    pub(super) enum UringReply {
+        Echo(Vec<u8>),
+    }
+
+    pub(super) fn uring_fixture() -> &'static UringFixture {
+        static FIXTURE: OnceLock<UringFixture> = OnceLock::new();
+        FIXTURE.get_or_init(|| {
+            let bind_addr: SocketAddr = "127.0.0.1:0".parse().expect("addr");
+            let (addr_tx, addr_rx) = std_mpsc::sync_channel::<SocketAddr>(1);
+            let (command_tx, command_rx) = std_mpsc::sync_channel::<UringCommand>(1024);
+            let (reply_tx, reply_rx) = std_mpsc::sync_channel::<UringReply>(1024);
+
+            let runtime_thread = thread::spawn(move || {
+                tokio_uring::start(async move {
+                    let mut listener =
+                        UringTcpTransport::bind_with(UringServerConfig::new(bind_addr))
+                            .await
+                            .expect("uring bind");
+                    let listen_addr = listener.local_addr().expect("local_addr");
+                    let _ = addr_tx.send(listen_addr);
+
+                    // Spawn an echo task on the same local set.
+                    tokio::task::spawn_local(async move {
+                        let mut conn = listener.accept().await.expect("accept");
+                        while let Ok(Some(msg)) = conn.recv().await {
+                            if conn.send(&msg).await.is_err() {
+                                break;
+                            }
+                        }
+                    });
+
+                    // Drive the bench client from the same local set.
+                    let server_addr = addr_rx.recv().expect("addr roundtrip not supported");
+                    let _ = server_addr;
+
+                    // Connect a single client and wait for command-driven
+                    // sends from the criterion thread via std::mpsc.
+                    let mut client =
+                        UringTcpTransport::connect_with(UringClientConfig::new(listen_addr))
+                            .await
+                            .expect("uring connect");
+
+                    while let Ok(cmd) = command_rx.recv() {
+                        match cmd {
+                            UringCommand::Send(payload) => {
+                                client.send(&payload).await.expect("uring send");
+                                let echo = client.recv().await.expect("uring recv").expect("frame");
+                                let _ = reply_tx.send(UringReply::Echo(echo.to_vec()));
+                            }
+                            UringCommand::Shutdown => break,
+                        }
+                    }
+                });
+            });
+            // The std::mpsc above ferries the bind addr back to the test
+            // thread.  We re-receive it here from the same channel via a
+            // second tap so the FIXTURE struct can store it.
+            //
+            // (The reason for the slightly awkward dance is that
+            // tokio_uring::start consumes its argument and we cannot
+            // share async-only state across the runtime boundary.)
+            let server_addr = addr_rx.recv().expect("addr");
+            UringFixture {
+                server_addr,
+                command_tx,
+                reply_rx,
+                _runtime_thread: runtime_thread,
+            }
+        })
+    }
+}
+
+#[cfg(all(feature = "tcp-uring", target_os = "linux"))]
+fn bench_tcp_uring_round_trip(c: &mut Criterion) {
+    let fixture = uring::uring_fixture();
+    let _ = fixture.server_addr; // logged for debug
+
+    let mut group = c.benchmark_group("transport_round_trip/tcp_uring");
+    group.measurement_time(Duration::from_secs(8));
+    group.sample_size(50);
+    group.bench_function("payload_64B", |b| {
+        let payload = make_payload();
+        b.iter(|| {
+            for _ in 0..ITERATIONS_PER_BATCH {
+                fixture
+                    .command_tx
+                    .send(uring::UringCommand::Send(payload.clone()))
+                    .expect("command send");
+                let reply = fixture.reply_rx.recv().expect("reply recv");
+                let uring::UringReply::Echo(echo) = reply;
+                black_box(echo);
+            }
+        });
+    });
+    group.finish();
+}
+
+#[cfg(not(all(feature = "tcp-uring", target_os = "linux")))]
+fn bench_tcp_uring_round_trip(_c: &mut Criterion) {
+    // Stub when the feature is disabled.  Criterion will simply skip the
+    // group; the bench binary still compiles everywhere.
+}
+
+criterion_group!(
+    benches,
+    bench_tcp_tokio_round_trip,
+    bench_tcp_uring_round_trip
+);
+criterion_main!(benches);

--- a/ironsbe-bench/benches/transport_round_trip.rs
+++ b/ironsbe-bench/benches/transport_round_trip.rs
@@ -128,12 +128,16 @@ mod uring {
     use super::*;
     use ironsbe_transport::tcp_uring::{UringClientConfig, UringServerConfig, UringTcpTransport};
     use ironsbe_transport::traits::{LocalConnection, LocalListener, LocalTransport};
+    use std::sync::Mutex;
     use std::sync::mpsc as std_mpsc;
 
     pub(super) struct UringFixture {
         pub(super) server_addr: SocketAddr,
         pub(super) command_tx: std_mpsc::SyncSender<UringCommand>,
-        pub(super) reply_rx: std_mpsc::Receiver<UringReply>,
+        // Receivers from std::mpsc are `!Sync`, so wrap in a Mutex to
+        // satisfy the `OnceLock` static-sharing bound.  The bench thread
+        // is the only consumer so contention is zero in practice.
+        pub(super) reply_rx: Mutex<std_mpsc::Receiver<UringReply>>,
         _runtime_thread: thread::JoinHandle<()>,
     }
 
@@ -156,6 +160,7 @@ mod uring {
 
             let runtime_thread = thread::spawn(move || {
                 tokio_uring::start(async move {
+                    // Bind the server side of the loop.
                     let mut listener =
                         UringTcpTransport::bind_with(UringServerConfig::new(bind_addr))
                             .await
@@ -163,7 +168,8 @@ mod uring {
                     let listen_addr = listener.local_addr().expect("local_addr");
                     let _ = addr_tx.send(listen_addr);
 
-                    // Spawn an echo task on the same local set.
+                    // Spawn an echo task on the same local set so the
+                    // bench client (also on this thread) has a peer.
                     tokio::task::spawn_local(async move {
                         let mut conn = listener.accept().await.expect("accept");
                         while let Ok(Some(msg)) = conn.recv().await {
@@ -173,17 +179,12 @@ mod uring {
                         }
                     });
 
-                    // Drive the bench client from the same local set.
-                    let server_addr = addr_rx.recv().expect("addr roundtrip not supported");
-                    let _ = server_addr;
-
-                    // Connect a single client and wait for command-driven
-                    // sends from the criterion thread via std::mpsc.
+                    // Connect the bench client and run the
+                    // command-driven send/recv loop until shutdown.
                     let mut client =
                         UringTcpTransport::connect_with(UringClientConfig::new(listen_addr))
                             .await
                             .expect("uring connect");
-
                     while let Ok(cmd) = command_rx.recv() {
                         match cmd {
                             UringCommand::Send(payload) => {
@@ -196,18 +197,13 @@ mod uring {
                     }
                 });
             });
-            // The std::mpsc above ferries the bind addr back to the test
-            // thread.  We re-receive it here from the same channel via a
-            // second tap so the FIXTURE struct can store it.
-            //
-            // (The reason for the slightly awkward dance is that
-            // tokio_uring::start consumes its argument and we cannot
-            // share async-only state across the runtime boundary.)
+            // The runtime thread sends the bound addr exactly once via
+            // `addr_tx`; we receive it here on the criterion thread.
             let server_addr = addr_rx.recv().expect("addr");
             UringFixture {
                 server_addr,
                 command_tx,
-                reply_rx,
+                reply_rx: Mutex::new(reply_rx),
                 _runtime_thread: runtime_thread,
             }
         })
@@ -230,7 +226,12 @@ fn bench_tcp_uring_round_trip(c: &mut Criterion) {
                     .command_tx
                     .send(uring::UringCommand::Send(payload.clone()))
                     .expect("command send");
-                let reply = fixture.reply_rx.recv().expect("reply recv");
+                let reply = fixture
+                    .reply_rx
+                    .lock()
+                    .expect("reply mutex poisoned")
+                    .recv()
+                    .expect("reply recv");
                 let uring::UringReply::Echo(echo) = reply;
                 black_box(echo);
             }

--- a/ironsbe-bench/benches/transport_round_trip.rs
+++ b/ironsbe-bench/benches/transport_round_trip.rs
@@ -1,7 +1,7 @@
 //! End-to-end transport round-trip benchmark.
 //!
-//! Measures the time to send a small SBE message from the client to the
-//! server and receive an echo back.  Compares the multi-threaded
+//! Measures the per-message round-trip latency of a 64-byte SBE payload
+//! over a persistent connection, comparing the multi-threaded
 //! `tcp-tokio` backend against the Linux-only `tcp-uring` backend (when
 //! the `tcp-uring` feature is enabled).
 //!
@@ -14,109 +14,138 @@
 //! # both backends (Linux >= 5.10):
 //! cargo bench -p ironsbe-bench --bench transport_round_trip --features tcp-uring
 //! ```
+//!
+//! Output is a markdown table ready to paste into the PR description and
+//! `docs/transport-backends.md`.  We deliberately do **not** use criterion's
+//! `iter` harness because:
+//!
+//! 1. criterion's default reporter prints `[lower_CI mean upper_CI]` of the
+//!    **mean**, not p50/p99/p99.9 — which is exactly what we need for a
+//!    transport latency benchmark.
+//! 2. We want all timing to happen on the runtime thread that owns the
+//!    connection, with zero cross-thread plumbing in the hot loop.  Each
+//!    backend's worker thread runs its own measurement loop with
+//!    `Instant::now()` and feeds an `hdrhistogram::Histogram`, then
+//!    returns the histogram to the main thread for reporting.
+//!
+//! This bench has `harness = false` in `Cargo.toml`, so it is just a
+//! plain binary with `fn main`.
 
-use criterion::{Criterion, criterion_group, criterion_main};
+use hdrhistogram::Histogram;
 use ironsbe_transport::tcp::{TcpClientConfig, TcpServerConfig, TokioTcpTransport};
-use ironsbe_transport::traits::{Connection, Transport};
-use std::hint::black_box;
+use ironsbe_transport::traits::Transport;
 use std::net::SocketAddr;
-use std::sync::Arc;
-use std::sync::OnceLock;
+use std::sync::mpsc;
 use std::thread;
-use std::time::Duration;
-use tokio::runtime::Runtime;
-use tokio::sync::oneshot;
+use std::time::{Duration, Instant};
 
 const PAYLOAD_LEN: usize = 64;
-const ITERATIONS_PER_BATCH: usize = 32;
+const WARMUP_ITERS: usize = 10_000;
+const MEASURE_ITERS: usize = 100_000;
 
-/// Builds a deterministic payload of the given length so the benchmark
-/// is reproducible across runs.
+/// Per-backend measurement result handed back to the main thread.
+struct BenchResult {
+    name: &'static str,
+    histogram: Histogram<u64>,
+}
+
+/// Builds a deterministic 64-byte payload so the bench is reproducible.
 fn make_payload() -> Vec<u8> {
     (0..PAYLOAD_LEN).map(|i| (i & 0xff) as u8).collect()
+}
+
+/// Renders a single result as one row of the markdown summary table.
+///
+/// Histogram values are stored in nanoseconds, so we format them as
+/// `µs` with three decimals to keep the table readable for typical
+/// loopback latencies.
+fn render_row(result: &BenchResult) {
+    let h = &result.histogram;
+    let p50 = h.value_at_quantile(0.50) as f64 / 1_000.0;
+    let p99 = h.value_at_quantile(0.99) as f64 / 1_000.0;
+    let p999 = h.value_at_quantile(0.999) as f64 / 1_000.0;
+    let mean_ns = h.mean();
+    let throughput = if mean_ns > 0.0 {
+        1e9 / mean_ns
+    } else {
+        f64::INFINITY
+    };
+    println!(
+        "| `{}` | {:.3} µs | {:.3} µs | {:.3} µs | {:>7.0} msg/s |",
+        result.name, p50, p99, p999, throughput,
+    );
 }
 
 // =====================================================================
 // tcp-tokio path
 // =====================================================================
 
-struct TokioFixture {
-    runtime: Arc<Runtime>,
-    server_addr: SocketAddr,
-    _server_thread: thread::JoinHandle<()>,
-}
+fn run_tcp_tokio_bench() -> BenchResult {
+    let bind_addr: SocketAddr = "127.0.0.1:0".parse().expect("addr");
+    let (addr_tx, addr_rx) = mpsc::sync_channel::<SocketAddr>(1);
+    let (result_tx, result_rx) = mpsc::sync_channel::<Histogram<u64>>(1);
 
-fn tokio_fixture() -> &'static TokioFixture {
-    static FIXTURE: OnceLock<TokioFixture> = OnceLock::new();
-    FIXTURE.get_or_init(|| {
-        let runtime = Arc::new(
-            tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(2)
-                .enable_all()
-                .build()
-                .expect("build tokio runtime"),
-        );
-        let bind_addr: SocketAddr = "127.0.0.1:0".parse().expect("addr");
-        let (addr_tx, addr_rx) = oneshot::channel();
-        let rt_clone = Arc::clone(&runtime);
-        let server_thread = thread::spawn(move || {
-            rt_clone.block_on(async move {
-                let mut listener = TokioTcpTransport::bind_with(TcpServerConfig::new(bind_addr))
-                    .await
-                    .expect("bind");
-                let listen_addr = listener.local_addr().expect("local_addr");
-                let _ = addr_tx.send(listen_addr);
-                loop {
-                    let conn = listener.accept().await.expect("accept");
-                    tokio::spawn(echo_loop_tokio(conn));
-                }
-            });
-        });
-        let server_addr = runtime.block_on(addr_rx).expect("addr");
-        TokioFixture {
-            runtime,
-            server_addr,
-            _server_thread: server_thread,
-        }
-    })
-}
-
-async fn echo_loop_tokio<C: Connection>(mut conn: C) {
-    while let Ok(Some(msg)) = conn.recv().await {
-        if conn.send(&msg).await.is_err() {
-            break;
-        }
-    }
-}
-
-fn bench_tcp_tokio_round_trip(c: &mut Criterion) {
-    let fixture = tokio_fixture();
-    let runtime = Arc::clone(&fixture.runtime);
-    let server_addr = fixture.server_addr;
-
-    let mut group = c.benchmark_group("transport_round_trip/tcp_tokio");
-    group.measurement_time(Duration::from_secs(8));
-    group.sample_size(50);
-    group.bench_function("payload_64B", |b| {
-        // Connect once, reuse the connection across iterations to keep
-        // the bench measuring round-trip latency, not connect cost.
-        let payload = make_payload();
-        let mut client = runtime.block_on(async {
-            TokioTcpTransport::connect_with(TcpClientConfig::new(server_addr))
+    // Spin up a dedicated multi-thread tokio runtime in its own thread.
+    // The runtime owns both the echo server and the bench client; the
+    // bench timing happens entirely on this thread so the criterion-side
+    // mpsc plumbing is **not** in the timed section.
+    let _runtime_thread = thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("build tokio runtime");
+        runtime.block_on(async move {
+            // Echo server.
+            let mut listener = TokioTcpTransport::bind_with(TcpServerConfig::new(bind_addr))
                 .await
-                .expect("connect")
-        });
-        b.iter(|| {
-            runtime.block_on(async {
-                for _ in 0..ITERATIONS_PER_BATCH {
-                    client.send(&payload).await.expect("send");
-                    let echo = client.recv().await.expect("recv").expect("frame");
-                    black_box(echo);
+                .expect("tokio bind");
+            let listen_addr = listener.local_addr().expect("local_addr");
+            let _ = addr_tx.send(listen_addr);
+
+            tokio::spawn(async move {
+                let mut conn = listener.accept().await.expect("accept");
+                while let Ok(Some(msg)) = conn.recv().await {
+                    if conn.send(&msg).await.is_err() {
+                        break;
+                    }
                 }
             });
+
+            // Bench client.
+            let mut client = TokioTcpTransport::connect_with(TcpClientConfig::new(listen_addr))
+                .await
+                .expect("tokio connect");
+            let payload = make_payload();
+
+            // Warmup.
+            for _ in 0..WARMUP_ITERS {
+                client.send(&payload).await.expect("warmup send");
+                let _ = client.recv().await.expect("warmup recv").expect("frame");
+            }
+
+            // Measurement.  Histogram tracks 1 ns .. 1 s, 3 sig figs.
+            let mut hist = Histogram::<u64>::new_with_bounds(1, 1_000_000_000, 3)
+                .expect("histogram bounds are valid");
+            for _ in 0..MEASURE_ITERS {
+                let start = Instant::now();
+                client.send(&payload).await.expect("measure send");
+                let _ = client.recv().await.expect("measure recv").expect("frame");
+                let elapsed = start.elapsed().as_nanos() as u64;
+                hist.record(elapsed.max(1)).expect("record");
+            }
+            let _ = result_tx.send(hist);
         });
     });
-    group.finish();
+
+    let _ = addr_rx.recv().expect("addr");
+    let histogram = result_rx
+        .recv_timeout(Duration::from_secs(120))
+        .expect("tcp-tokio bench timed out");
+    BenchResult {
+        name: "tcp-tokio",
+        histogram,
+    }
 }
 
 // =====================================================================
@@ -124,125 +153,97 @@ fn bench_tcp_tokio_round_trip(c: &mut Criterion) {
 // =====================================================================
 
 #[cfg(all(feature = "tcp-uring", target_os = "linux"))]
-mod uring {
-    use super::*;
+fn run_tcp_uring_bench() -> Option<BenchResult> {
     use ironsbe_transport::tcp_uring::{UringClientConfig, UringServerConfig, UringTcpTransport};
     use ironsbe_transport::traits::{LocalConnection, LocalListener, LocalTransport};
-    use std::sync::Mutex;
-    use std::sync::mpsc as std_mpsc;
 
-    pub(super) struct UringFixture {
-        pub(super) server_addr: SocketAddr,
-        pub(super) command_tx: std_mpsc::SyncSender<UringCommand>,
-        // Receivers from std::mpsc are `!Sync`, so wrap in a Mutex to
-        // satisfy the `OnceLock` static-sharing bound.  The bench thread
-        // is the only consumer so contention is zero in practice.
-        pub(super) reply_rx: Mutex<std_mpsc::Receiver<UringReply>>,
-        _runtime_thread: thread::JoinHandle<()>,
-    }
+    let bind_addr: SocketAddr = "127.0.0.1:0".parse().expect("addr");
+    let (addr_tx, addr_rx) = mpsc::sync_channel::<SocketAddr>(1);
+    let (result_tx, result_rx) = mpsc::sync_channel::<Histogram<u64>>(1);
 
-    pub(super) enum UringCommand {
-        Send(Vec<u8>),
-    }
+    let _runtime_thread = thread::spawn(move || {
+        tokio_uring::start(async move {
+            // Echo server.
+            let mut listener = UringTcpTransport::bind_with(UringServerConfig::new(bind_addr))
+                .await
+                .expect("uring bind");
+            let listen_addr = listener.local_addr().expect("local_addr");
+            let _ = addr_tx.send(listen_addr);
 
-    pub(super) enum UringReply {
-        Echo(Vec<u8>),
-    }
-
-    pub(super) fn uring_fixture() -> &'static UringFixture {
-        static FIXTURE: OnceLock<UringFixture> = OnceLock::new();
-        FIXTURE.get_or_init(|| {
-            let bind_addr: SocketAddr = "127.0.0.1:0".parse().expect("addr");
-            let (addr_tx, addr_rx) = std_mpsc::sync_channel::<SocketAddr>(1);
-            let (command_tx, command_rx) = std_mpsc::sync_channel::<UringCommand>(1024);
-            let (reply_tx, reply_rx) = std_mpsc::sync_channel::<UringReply>(1024);
-
-            let runtime_thread = thread::spawn(move || {
-                tokio_uring::start(async move {
-                    // Bind the server side of the loop.
-                    let mut listener =
-                        UringTcpTransport::bind_with(UringServerConfig::new(bind_addr))
-                            .await
-                            .expect("uring bind");
-                    let listen_addr = listener.local_addr().expect("local_addr");
-                    let _ = addr_tx.send(listen_addr);
-
-                    // Spawn an echo task on the same local set so the
-                    // bench client (also on this thread) has a peer.
-                    tokio::task::spawn_local(async move {
-                        let mut conn = listener.accept().await.expect("accept");
-                        while let Ok(Some(msg)) = conn.recv().await {
-                            if conn.send(&msg).await.is_err() {
-                                break;
-                            }
-                        }
-                    });
-
-                    // Connect the bench client and run the
-                    // command-driven send/recv loop until shutdown.
-                    let mut client =
-                        UringTcpTransport::connect_with(UringClientConfig::new(listen_addr))
-                            .await
-                            .expect("uring connect");
-                    while let Ok(UringCommand::Send(payload)) = command_rx.recv() {
-                        client.send(&payload).await.expect("uring send");
-                        let echo = client.recv().await.expect("uring recv").expect("frame");
-                        let _ = reply_tx.send(UringReply::Echo(echo.to_vec()));
+            tokio::task::spawn_local(async move {
+                let mut conn = listener.accept().await.expect("accept");
+                while let Ok(Some(msg)) = conn.recv().await {
+                    if conn.send(&msg).await.is_err() {
+                        break;
                     }
-                });
+                }
             });
-            // The runtime thread sends the bound addr exactly once via
-            // `addr_tx`; we receive it here on the criterion thread.
-            let server_addr = addr_rx.recv().expect("addr");
-            UringFixture {
-                server_addr,
-                command_tx,
-                reply_rx: Mutex::new(reply_rx),
-                _runtime_thread: runtime_thread,
-            }
-        })
-    }
-}
 
-#[cfg(all(feature = "tcp-uring", target_os = "linux"))]
-fn bench_tcp_uring_round_trip(c: &mut Criterion) {
-    let fixture = uring::uring_fixture();
-    let _ = fixture.server_addr; // logged for debug
+            // Bench client.
+            let mut client = UringTcpTransport::connect_with(UringClientConfig::new(listen_addr))
+                .await
+                .expect("uring connect");
+            let payload = make_payload();
 
-    let mut group = c.benchmark_group("transport_round_trip/tcp_uring");
-    group.measurement_time(Duration::from_secs(8));
-    group.sample_size(50);
-    group.bench_function("payload_64B", |b| {
-        let payload = make_payload();
-        b.iter(|| {
-            for _ in 0..ITERATIONS_PER_BATCH {
-                fixture
-                    .command_tx
-                    .send(uring::UringCommand::Send(payload.clone()))
-                    .expect("command send");
-                let reply = fixture
-                    .reply_rx
-                    .lock()
-                    .expect("reply mutex poisoned")
-                    .recv()
-                    .expect("reply recv");
-                let uring::UringReply::Echo(echo) = reply;
-                black_box(echo);
+            // Warmup.
+            for _ in 0..WARMUP_ITERS {
+                client.send(&payload).await.expect("warmup send");
+                let _ = client.recv().await.expect("warmup recv").expect("frame");
             }
+
+            // Measurement, single threaded, zero cross-thread overhead
+            // in the hot loop.
+            let mut hist = Histogram::<u64>::new_with_bounds(1, 1_000_000_000, 3)
+                .expect("histogram bounds are valid");
+            for _ in 0..MEASURE_ITERS {
+                let start = Instant::now();
+                client.send(&payload).await.expect("measure send");
+                let _ = client.recv().await.expect("measure recv").expect("frame");
+                let elapsed = start.elapsed().as_nanos() as u64;
+                hist.record(elapsed.max(1)).expect("record");
+            }
+            let _ = result_tx.send(hist);
         });
     });
-    group.finish();
+
+    let _ = addr_rx.recv().expect("addr");
+    let histogram = result_rx
+        .recv_timeout(Duration::from_secs(120))
+        .expect("tcp-uring bench timed out");
+    Some(BenchResult {
+        name: "tcp-uring",
+        histogram,
+    })
 }
 
 #[cfg(not(all(feature = "tcp-uring", target_os = "linux")))]
-fn bench_tcp_uring_round_trip(_c: &mut Criterion) {
-    // Stub when the feature is disabled.  Criterion will simply skip the
-    // group; the bench binary still compiles everywhere.
+fn run_tcp_uring_bench() -> Option<BenchResult> {
+    None
 }
 
-criterion_group!(
-    benches,
-    bench_tcp_tokio_round_trip,
-    bench_tcp_uring_round_trip
-);
-criterion_main!(benches);
+// =====================================================================
+// main
+// =====================================================================
+
+fn main() {
+    println!(
+        "Running transport_round_trip ({}-byte payload, {} warmup + {} measured iterations per backend)",
+        PAYLOAD_LEN, WARMUP_ITERS, MEASURE_ITERS,
+    );
+    println!();
+
+    let mut results = vec![run_tcp_tokio_bench()];
+    if let Some(uring) = run_tcp_uring_bench() {
+        results.push(uring);
+    } else {
+        println!(
+            "(tcp-uring backend not built — enable with --features tcp-uring on Linux >= 5.10)\n"
+        );
+    }
+
+    println!("| Backend     |       p50 |       p99 |     p99.9 |    Throughput |");
+    println!("|-------------|-----------|-----------|-----------|---------------|");
+    for result in &results {
+        render_row(result);
+    }
+}

--- a/ironsbe-client/Cargo.toml
+++ b/ironsbe-client/Cargo.toml
@@ -13,6 +13,9 @@ categories = ["network-programming", "asynchronous"]
 [features]
 default = ["tcp-tokio"]
 tcp-tokio = ["ironsbe-transport/tcp-tokio"]
+# Linux-only io_uring backend.  Enables the LocalClient and integration
+# tests against the matching transport feature.
+tcp-uring = ["ironsbe-transport/tcp-uring"]
 
 [dependencies]
 ironsbe-core = { workspace = true }

--- a/ironsbe-client/src/builder.rs
+++ b/ironsbe-client/src/builder.rs
@@ -325,6 +325,25 @@ pub struct ClientHandle {
 }
 
 impl ClientHandle {
+    /// Constructs a [`ClientHandle`] from its raw plumbing.
+    ///
+    /// Used internally by both the multi-threaded [`Client`] builder and
+    /// the single-threaded `LocalClient` builder so both client flavours
+    /// can hand back the same handle type.
+    pub(crate) fn new(
+        cmd_tx: spsc::SpscSender<ClientCommand>,
+        event_rx: spsc::SpscReceiver<ClientEvent>,
+        cmd_notify: Arc<Notify>,
+        event_notify: Arc<Notify>,
+    ) -> Self {
+        Self {
+            cmd_tx,
+            event_rx,
+            cmd_notify,
+            event_notify,
+        }
+    }
+
     /// Sends an SBE message to the server (non-blocking).
     ///
     /// # Errors

--- a/ironsbe-client/src/lib.rs
+++ b/ironsbe-client/src/lib.rs
@@ -9,8 +9,10 @@
 
 pub mod builder;
 pub mod error;
+pub mod local_builder;
 pub mod reconnect;
 pub mod session;
 
 pub use builder::{Client, ClientBuilder, ClientCommand, ClientEvent, ClientHandle};
 pub use error::ClientError;
+pub use local_builder::{LocalClient, LocalClientBuilder};

--- a/ironsbe-client/src/local_builder.rs
+++ b/ironsbe-client/src/local_builder.rs
@@ -1,0 +1,237 @@
+//! Single-threaded client builder for thread-per-core / `!Send` backends.
+//!
+//! Mirrors [`crate::ClientBuilder`] but is generic over [`LocalTransport`]
+//! instead of [`Transport`](ironsbe_transport::Transport).  Use this when
+//! the chosen backend (e.g. `tokio-uring` via the `tcp-uring` feature) is
+//! single-threaded by construction.
+//!
+//! [`LocalClient::run`] must be polled inside a single-threaded reactor
+//! that owns a Tokio `LocalSet` (typically `tokio_uring::start`).
+
+use crate::builder::{ClientCommand, ClientEvent, ClientHandle};
+use crate::error::ClientError;
+use crate::reconnect::{ReconnectConfig, ReconnectState};
+use ironsbe_channel::spsc;
+use ironsbe_transport::traits::{LocalConnection, LocalTransport};
+use std::marker::PhantomData;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Notify;
+
+/// Builder for [`LocalClient`].
+///
+/// Single-threaded counterpart of [`crate::ClientBuilder`]; the type
+/// parameter `T` selects a [`LocalTransport`] backend rather than the
+/// multi-threaded [`Transport`](ironsbe_transport::Transport) family.
+pub struct LocalClientBuilder<T: LocalTransport> {
+    server_addr: SocketAddr,
+    connect_config: Option<T::ConnectConfig>,
+    connect_timeout: Duration,
+    reconnect_config: ReconnectConfig,
+    channel_capacity: usize,
+    _transport: PhantomData<T>,
+}
+
+impl<T: LocalTransport> LocalClientBuilder<T> {
+    /// Creates a new local client builder targeting `server_addr`.
+    #[must_use]
+    pub fn new(server_addr: SocketAddr) -> Self {
+        Self {
+            server_addr,
+            connect_config: None,
+            connect_timeout: Duration::from_secs(5),
+            reconnect_config: ReconnectConfig::default(),
+            channel_capacity: 4096,
+            _transport: PhantomData,
+        }
+    }
+
+    /// Supplies a backend-specific connect configuration.
+    #[must_use]
+    pub fn connect_config(mut self, config: T::ConnectConfig) -> Self {
+        self.connect_config = Some(config);
+        self
+    }
+
+    /// Sets the outer connect timeout used by the reconnect loop.
+    #[must_use]
+    pub fn connect_timeout(mut self, timeout: Duration) -> Self {
+        self.connect_timeout = timeout;
+        self
+    }
+
+    /// Enables or disables automatic reconnection.
+    #[must_use]
+    pub fn reconnect(mut self, enabled: bool) -> Self {
+        self.reconnect_config.enabled = enabled;
+        self
+    }
+
+    /// Sets the reconnection delay.
+    #[must_use]
+    pub fn reconnect_delay(mut self, delay: Duration) -> Self {
+        self.reconnect_config.initial_delay = delay;
+        self
+    }
+
+    /// Sets the maximum reconnection attempts.
+    #[must_use]
+    pub fn max_reconnect_attempts(mut self, max: usize) -> Self {
+        self.reconnect_config.max_attempts = max;
+        self
+    }
+
+    /// Sets the cmd/event channel capacity.
+    #[must_use]
+    pub fn channel_capacity(mut self, capacity: usize) -> Self {
+        self.channel_capacity = capacity;
+        self
+    }
+
+    /// Builds the client and its external handle.
+    #[must_use]
+    pub fn build(self) -> (LocalClient<T>, ClientHandle) {
+        let (cmd_tx, cmd_rx) = spsc::channel(self.channel_capacity);
+        let (event_tx, event_rx) = spsc::channel(self.channel_capacity);
+        let cmd_notify = Arc::new(Notify::new());
+        let event_notify = Arc::new(Notify::new());
+
+        let client = LocalClient {
+            server_addr: self.server_addr,
+            connect_config: Some(
+                self.connect_config
+                    .unwrap_or_else(|| T::ConnectConfig::from(self.server_addr)),
+            ),
+            connect_timeout: self.connect_timeout,
+            reconnect_state: ReconnectState::new(self.reconnect_config),
+            cmd_rx,
+            event_tx,
+            cmd_notify: Arc::clone(&cmd_notify),
+            event_notify: Arc::clone(&event_notify),
+            _transport: PhantomData,
+        };
+
+        let handle = ClientHandle::new(cmd_tx, event_rx, cmd_notify, event_notify);
+        (client, handle)
+    }
+}
+
+/// Single-threaded client instance for [`LocalTransport`] backends.
+///
+/// `LocalClient::run` **must** be polled inside a Tokio `LocalSet`
+/// (typically `tokio_uring::start(async move { client.run().await })`).
+pub struct LocalClient<T: LocalTransport> {
+    server_addr: SocketAddr,
+    connect_config: Option<T::ConnectConfig>,
+    connect_timeout: Duration,
+    reconnect_state: ReconnectState,
+    cmd_rx: spsc::SpscReceiver<ClientCommand>,
+    event_tx: spsc::SpscSender<ClientEvent>,
+    cmd_notify: Arc<Notify>,
+    event_notify: Arc<Notify>,
+    _transport: PhantomData<T>,
+}
+
+impl<T: LocalTransport> LocalClient<T> {
+    /// Runs the client, connecting and processing messages until shutdown.
+    ///
+    /// # Errors
+    /// Returns [`ClientError`] if the connection fails repeatedly or the
+    /// session encounters an unrecoverable error.
+    pub async fn run(&mut self) -> Result<(), ClientError> {
+        loop {
+            match self.connect_and_run().await {
+                Ok(()) => return Ok(()),
+                Err(e) => {
+                    tracing::error!("Local client connection error: {:?}", e);
+                    if let Some(delay) = self.reconnect_state.on_failure() {
+                        let _ = self.event_tx.send(ClientEvent::Disconnected);
+                        self.event_notify.notify_one();
+                        tracing::info!("Reconnecting in {:?}...", delay);
+                        tokio::time::sleep(delay).await;
+                    } else {
+                        tracing::error!("Max reconnect attempts reached");
+                        return Err(ClientError::MaxReconnectAttempts);
+                    }
+                }
+            }
+        }
+    }
+
+    async fn connect_and_run(&mut self) -> Result<(), ClientError> {
+        // Reconnect attempts share the same connect_config; clone on
+        // each attempt so a custom config survives across reconnects.
+        let connect_config = self
+            .connect_config
+            .clone()
+            .unwrap_or_else(|| T::ConnectConfig::from(self.server_addr));
+        let mut conn = tokio::time::timeout(self.connect_timeout, T::connect_with(connect_config))
+            .await
+            .map_err(|_| ClientError::ConnectTimeout)?
+            .map_err(|e| ClientError::Io(std::io::Error::other(e.to_string())))?;
+
+        self.reconnect_state.on_success();
+
+        let _ = self.event_tx.send(ClientEvent::Connected);
+        self.event_notify.notify_one();
+        tracing::info!("Local client connected to {}", self.server_addr);
+
+        loop {
+            tokio::select! {
+                _ = self.cmd_notify.notified() => {
+                    while let Some(cmd) = self.cmd_rx.recv() {
+                        match cmd {
+                            ClientCommand::Send(msg) => {
+                                conn.send(&msg)
+                                    .await
+                                    .map_err(|e| ClientError::Io(std::io::Error::other(e.to_string())))?;
+                            }
+                            ClientCommand::Disconnect => return Ok(()),
+                        }
+                    }
+                }
+
+                result = conn.recv() => {
+                    match result {
+                        Ok(Some(msg)) => {
+                            let _ = self.event_tx.send(ClientEvent::Message(msg.to_vec()));
+                            self.event_notify.notify_one();
+                        }
+                        Ok(None) => return Err(ClientError::ConnectionClosed),
+                        Err(e) => {
+                            return Err(ClientError::Io(std::io::Error::other(e.to_string())));
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(all(test, feature = "tcp-uring", target_os = "linux"))]
+mod tests {
+    use super::*;
+    use ironsbe_transport::tcp_uring::UringTcpTransport;
+
+    #[test]
+    fn test_local_client_builder_new() {
+        let addr: SocketAddr = "127.0.0.1:9000".parse().expect("test addr");
+        let builder = LocalClientBuilder::<UringTcpTransport>::new(addr);
+        let _ = builder;
+    }
+
+    #[test]
+    fn test_local_client_builder_connect_timeout() {
+        let addr: SocketAddr = "127.0.0.1:9000".parse().expect("test addr");
+        let builder = LocalClientBuilder::<UringTcpTransport>::new(addr)
+            .connect_timeout(Duration::from_secs(2));
+        let _ = builder;
+    }
+
+    #[test]
+    fn test_local_client_builder_build() {
+        let addr: SocketAddr = "127.0.0.1:9000".parse().expect("test addr");
+        let (_client, _handle) = LocalClientBuilder::<UringTcpTransport>::new(addr).build();
+    }
+}

--- a/ironsbe-server/Cargo.toml
+++ b/ironsbe-server/Cargo.toml
@@ -13,6 +13,9 @@ categories = ["network-programming", "asynchronous"]
 [features]
 default = ["tcp-tokio"]
 tcp-tokio = ["ironsbe-transport/tcp-tokio"]
+# Linux-only io_uring backend.  Brings in the LocalServer integration
+# tests and gates them on Linux + the matching transport feature.
+tcp-uring = ["ironsbe-transport/tcp-uring"]
 
 [dependencies]
 ironsbe-core = { workspace = true }
@@ -29,3 +32,8 @@ futures = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+ironsbe-client = { workspace = true }
+ironsbe-core = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+tokio-uring = { workspace = true }

--- a/ironsbe-server/src/builder.rs
+++ b/ironsbe-server/src/builder.rs
@@ -353,7 +353,7 @@ impl ServerHandle {
 }
 
 /// Commands that can be sent to the server.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ServerCommand {
     /// Shutdown the server.
     Shutdown,
@@ -366,6 +366,10 @@ pub enum ServerCommand {
 /// Events emitted by the server.
 #[derive(Debug, Clone)]
 pub enum ServerEvent {
+    /// The server has bound its listener and is ready to accept
+    /// connections.  Carries the *effective* local address (useful when
+    /// the caller bound to port 0).
+    Listening(SocketAddr),
     /// A new session was created.
     SessionCreated(u64, SocketAddr),
     /// A session was closed.

--- a/ironsbe-server/src/builder.rs
+++ b/ironsbe-server/src/builder.rs
@@ -309,6 +309,23 @@ pub struct ServerHandle {
 }
 
 impl ServerHandle {
+    /// Constructs a [`ServerHandle`] from its raw plumbing.
+    ///
+    /// Used internally by the multi-threaded [`Server`] builder and by
+    /// the single-threaded `LocalServer` builder so both server flavours
+    /// can hand back the same handle type.
+    pub(crate) fn new(
+        cmd_tx: MpscSender<ServerCommand>,
+        event_rx: MpscReceiver<ServerEvent>,
+        cmd_notify: Arc<Notify>,
+    ) -> Self {
+        Self {
+            cmd_tx,
+            event_rx,
+            cmd_notify,
+        }
+    }
+
     /// Requests server shutdown.
     pub fn shutdown(&self) {
         let _ = self.cmd_tx.try_send(ServerCommand::Shutdown);

--- a/ironsbe-server/src/lib.rs
+++ b/ironsbe-server/src/lib.rs
@@ -12,10 +12,12 @@ pub mod builder;
 pub mod dispatcher;
 pub mod error;
 pub mod handler;
+pub mod local_builder;
 pub mod session;
 
 pub use builder::{Server, ServerBuilder, ServerCommand, ServerEvent, ServerHandle};
 pub use dispatcher::MessageDispatcher;
 pub use error::ServerError;
 pub use handler::{MessageHandler, Responder, TypedHandler};
+pub use local_builder::{LocalServer, LocalServerBuilder};
 pub use session::SessionManager;

--- a/ironsbe-server/src/local_builder.rs
+++ b/ironsbe-server/src/local_builder.rs
@@ -113,6 +113,7 @@ impl<H: MessageHandler, T: LocalTransport> LocalServerBuilder<H, T> {
             ),
             handler: Rc::new(handler),
             max_connections: self.max_connections,
+            cmd_tx: cmd_tx.clone(),
             cmd_rx,
             event_tx,
             sessions: SessionManager::new(),
@@ -143,6 +144,10 @@ pub struct LocalServer<H, T: LocalTransport> {
     bind_config: Option<T::BindConfig>,
     handler: Rc<H>,
     max_connections: usize,
+    /// Cloned and handed to per-session tasks so they can fire
+    /// `ServerCommand::CloseSession` when the session ends, freeing the
+    /// `SessionManager` slot back in the run loop.
+    cmd_tx: MpscSender<ServerCommand>,
     cmd_rx: MpscReceiver<ServerCommand>,
     event_tx: MpscSender<ServerEvent>,
     sessions: SessionManager,
@@ -175,6 +180,12 @@ where
             .map_err(|e| ServerError::Io(std::io::Error::other(e.to_string())))?;
         let effective_addr = listener.local_addr().unwrap_or(self.bind_addr);
         tracing::info!("Local server listening on {}", effective_addr);
+        // Notify any external observer (test harness, supervisor) of
+        // the effective bound address.  Best-effort: dropping the event
+        // is fine if no one is listening.
+        let _ = self
+            .event_tx
+            .try_send(ServerEvent::Listening(effective_addr));
 
         loop {
             tokio::select! {
@@ -212,6 +223,12 @@ where
         let session_id = self.sessions.create_session(addr);
         let handler = Rc::clone(&self.handler);
         let event_tx = self.event_tx.clone();
+        // Cloned cmd_tx so the spawned task can fire CloseSession back
+        // to the run loop on disconnect, releasing the SessionManager
+        // slot.  Without this the slot leaks and `max_connections`
+        // eventually rejects every new connection.
+        let cmd_tx = self.cmd_tx.clone();
+        let cmd_notify = Arc::clone(&self.cmd_notify);
 
         handler.on_session_start(session_id);
         let _ = event_tx.try_send(ServerEvent::SessionCreated(session_id, addr));
@@ -225,6 +242,9 @@ where
             }
             handler.on_session_end(session_id);
             let _ = event_tx.try_send(ServerEvent::SessionClosed(session_id));
+            // Ask the run loop to release the SessionManager slot.
+            let _ = cmd_tx.try_send(ServerCommand::CloseSession(session_id));
+            cmd_notify.notify_one();
         });
     }
 

--- a/ironsbe-server/src/local_builder.rs
+++ b/ironsbe-server/src/local_builder.rs
@@ -1,0 +1,373 @@
+//! Single-threaded server builder for thread-per-core / `!Send` backends.
+//!
+//! Mirrors [`crate::ServerBuilder`] but is generic over [`LocalTransport`]
+//! instead of [`Transport`](ironsbe_transport::Transport).  Use this when
+//! the chosen backend (e.g. `tokio-uring` via the `tcp-uring` feature) is
+//! single-threaded by construction and its handle types are `!Send`.
+//!
+//! # Runtime requirements
+//!
+//! [`LocalServer::run`] must be polled inside a single-threaded reactor
+//! that owns a Tokio `LocalSet` (or anything with the same semantics).
+//! `tokio_uring::start` provides one for free; for plain `tokio` you can
+//! use `tokio::task::LocalSet::run_until`.
+
+use crate::error::ServerError;
+use crate::handler::{MessageHandler, Responder, SendError};
+use crate::session::SessionManager;
+use ironsbe_channel::mpsc::{MpscChannel, MpscReceiver, MpscSender};
+use ironsbe_core::header::MessageHeader;
+use ironsbe_transport::traits::{LocalConnection, LocalListener, LocalTransport};
+use std::marker::PhantomData;
+use std::net::SocketAddr;
+use std::rc::Rc;
+use std::sync::Arc;
+use tokio::sync::{Notify, mpsc as tokio_mpsc};
+
+use crate::builder::{ServerCommand, ServerEvent, ServerHandle};
+
+/// Builder for [`LocalServer`].
+///
+/// Single-threaded counterpart of [`crate::ServerBuilder`]; the type
+/// parameter `T` selects a [`LocalTransport`] backend rather than the
+/// multi-threaded [`Transport`](ironsbe_transport::Transport) family.
+pub struct LocalServerBuilder<H, T: LocalTransport> {
+    bind_addr: SocketAddr,
+    bind_config: Option<T::BindConfig>,
+    handler: Option<H>,
+    max_connections: usize,
+    channel_capacity: usize,
+    _transport: PhantomData<T>,
+}
+
+impl<H: MessageHandler, T: LocalTransport> LocalServerBuilder<H, T> {
+    /// Creates a new local server builder with default settings.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            bind_addr: "0.0.0.0:9000"
+                .parse()
+                .expect("hardcoded default bind addr is valid"),
+            bind_config: None,
+            handler: None,
+            max_connections: 1000,
+            channel_capacity: 4096,
+            _transport: PhantomData,
+        }
+    }
+
+    /// Sets the bind address.  Clears any previously-supplied
+    /// [`bind_config`](Self::bind_config) since the address is now
+    /// ambiguous.
+    #[must_use]
+    pub fn bind(mut self, addr: SocketAddr) -> Self {
+        self.bind_addr = addr;
+        self.bind_config = None;
+        self
+    }
+
+    /// Supplies a backend-specific bind configuration.
+    #[must_use]
+    pub fn bind_config(mut self, config: T::BindConfig) -> Self {
+        self.bind_config = Some(config);
+        self
+    }
+
+    /// Sets the message handler.
+    #[must_use]
+    pub fn handler(mut self, handler: H) -> Self {
+        self.handler = Some(handler);
+        self
+    }
+
+    /// Sets the maximum number of concurrent sessions.
+    #[must_use]
+    pub fn max_connections(mut self, max: usize) -> Self {
+        self.max_connections = max;
+        self
+    }
+
+    /// Sets the cmd/event channel capacity.
+    #[must_use]
+    pub fn channel_capacity(mut self, capacity: usize) -> Self {
+        self.channel_capacity = capacity;
+        self
+    }
+
+    /// Builds the server and its external handle.
+    ///
+    /// # Panics
+    /// Panics if no [`handler`](Self::handler) was set.
+    #[must_use]
+    pub fn build(self) -> (LocalServer<H, T>, ServerHandle) {
+        let handler = self.handler.expect("Handler required");
+        let (cmd_tx, cmd_rx) = MpscChannel::bounded(self.channel_capacity);
+        let (event_tx, event_rx) = MpscChannel::bounded(self.channel_capacity);
+        let cmd_notify = Arc::new(Notify::new());
+
+        let server = LocalServer {
+            bind_addr: self.bind_addr,
+            bind_config: Some(
+                self.bind_config
+                    .unwrap_or_else(|| T::BindConfig::from(self.bind_addr)),
+            ),
+            handler: Rc::new(handler),
+            max_connections: self.max_connections,
+            cmd_rx,
+            event_tx,
+            sessions: SessionManager::new(),
+            cmd_notify: Arc::clone(&cmd_notify),
+            _transport: PhantomData,
+        };
+
+        let handle = ServerHandle::new(cmd_tx, event_rx, cmd_notify);
+        (server, handle)
+    }
+}
+
+impl<H: MessageHandler, T: LocalTransport> Default for LocalServerBuilder<H, T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Single-threaded server instance for [`LocalTransport`] backends.
+///
+/// `LocalServer::run` **must** be polled inside a Tokio `LocalSet` (e.g.
+/// from inside `tokio_uring::start(async { server.run().await })`).
+/// Polling it from a context without a `LocalSet` will fail at the first
+/// `spawn_local` call.
+#[allow(dead_code)]
+pub struct LocalServer<H, T: LocalTransport> {
+    bind_addr: SocketAddr,
+    bind_config: Option<T::BindConfig>,
+    handler: Rc<H>,
+    max_connections: usize,
+    cmd_rx: MpscReceiver<ServerCommand>,
+    event_tx: MpscSender<ServerEvent>,
+    sessions: SessionManager,
+    cmd_notify: Arc<Notify>,
+    _transport: PhantomData<T>,
+}
+
+impl<H, T> LocalServer<H, T>
+where
+    H: MessageHandler + 'static,
+    T: LocalTransport,
+    T::Connection: 'static,
+{
+    /// Runs the server, accepting connections and processing messages.
+    ///
+    /// # Errors
+    /// Returns [`ServerError`] if the listener fails to bind or the
+    /// accept loop encounters an unrecoverable error.
+    ///
+    /// # Panics
+    /// Panics indirectly via `tokio::task::spawn_local` if called outside
+    /// a `LocalSet` context.  See the type-level docs.
+    pub async fn run(&mut self) -> Result<(), ServerError> {
+        let bind_config = self
+            .bind_config
+            .take()
+            .unwrap_or_else(|| T::BindConfig::from(self.bind_addr));
+        let mut listener = T::bind_with(bind_config)
+            .await
+            .map_err(|e| ServerError::Io(std::io::Error::other(e.to_string())))?;
+        let effective_addr = listener.local_addr().unwrap_or(self.bind_addr);
+        tracing::info!("Local server listening on {}", effective_addr);
+
+        loop {
+            tokio::select! {
+                result = listener.accept() => {
+                    match result {
+                        Ok(conn) => {
+                            let addr = conn
+                                .peer_addr()
+                                .unwrap_or_else(|_| "0.0.0.0:0".parse().expect("placeholder"));
+                            self.handle_connection(conn, addr);
+                        }
+                        Err(e) => {
+                            tracing::error!("Local accept error: {}", e);
+                        }
+                    }
+                }
+
+                _ = self.cmd_notify.notified() => {
+                    while let Some(cmd) = self.cmd_rx.try_recv() {
+                        if self.handle_command(cmd).await {
+                            return Ok(());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn handle_connection(&mut self, conn: T::Connection, addr: SocketAddr) {
+        if self.sessions.count() >= self.max_connections {
+            tracing::warn!("Max connections reached, rejecting {}", addr);
+            return;
+        }
+
+        let session_id = self.sessions.create_session(addr);
+        let handler = Rc::clone(&self.handler);
+        let event_tx = self.event_tx.clone();
+
+        handler.on_session_start(session_id);
+        let _ = event_tx.try_send(ServerEvent::SessionCreated(session_id, addr));
+
+        // `spawn_local` keeps the future on the current single-threaded
+        // runtime, satisfying the `!Send` connection bound.
+        tokio::task::spawn_local(async move {
+            tracing::info!("Local session {} connected from {}", session_id, addr);
+            if let Err(e) = handle_local_session(session_id, conn, handler.as_ref()).await {
+                tracing::error!("Local session {} error: {:?}", session_id, e);
+            }
+            handler.on_session_end(session_id);
+            let _ = event_tx.try_send(ServerEvent::SessionClosed(session_id));
+        });
+    }
+
+    async fn handle_command(&mut self, cmd: ServerCommand) -> bool {
+        match cmd {
+            ServerCommand::Shutdown => {
+                tracing::info!("Local server shutdown requested");
+                true
+            }
+            ServerCommand::CloseSession(session_id) => {
+                self.sessions.close_session(session_id);
+                false
+            }
+            ServerCommand::Broadcast(_message) => false,
+        }
+    }
+}
+
+/// Per-session responder that ferries handler outputs back to the
+/// connection writer over an unbounded local channel.  Mirrors the
+/// equivalent type in [`crate::builder`].
+struct LocalSessionResponder {
+    tx: tokio_mpsc::UnboundedSender<Vec<u8>>,
+}
+
+impl Responder for LocalSessionResponder {
+    fn send(&self, message: &[u8]) -> Result<(), SendError> {
+        self.tx.send(message.to_vec()).map_err(|_| SendError {
+            message: "channel closed".to_string(),
+        })
+    }
+
+    fn send_to(&self, _session_id: u64, message: &[u8]) -> Result<(), SendError> {
+        self.send(message)
+    }
+}
+
+/// Drives one [`LocalConnection`] end-to-end: read framed SBE messages,
+/// dispatch to the handler, and write any responses produced by the
+/// handler back over the same connection.
+///
+/// Mirrors the [`Connection`](ironsbe_transport::traits::Connection)
+/// version in [`crate::builder`].
+async fn handle_local_session<H, C>(
+    session_id: u64,
+    mut conn: C,
+    handler: &H,
+) -> Result<(), std::io::Error>
+where
+    H: MessageHandler,
+    C: LocalConnection,
+{
+    let (tx, mut rx) = tokio_mpsc::unbounded_channel::<Vec<u8>>();
+    let responder = LocalSessionResponder { tx };
+
+    loop {
+        tokio::select! {
+            result = conn.recv() => {
+                match result {
+                    Ok(Some(data)) => {
+                        if data.len() >= MessageHeader::ENCODED_LENGTH {
+                            let header = MessageHeader::wrap(data.as_ref(), 0);
+                            handler.on_message(session_id, &header, data.as_ref(), &responder);
+                        } else {
+                            handler.on_error(session_id, "Message too short for header");
+                        }
+                    }
+                    Ok(None) => {
+                        tracing::info!("Local session {} disconnected", session_id);
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        tracing::error!("Local session {} read error: {}", session_id, e);
+                        return Err(std::io::Error::other(e.to_string()));
+                    }
+                }
+            }
+
+            Some(msg) = rx.recv() => {
+                if let Err(e) = conn.send(&msg).await {
+                    tracing::error!("Local session {} write error: {}", session_id, e);
+                    return Err(std::io::Error::other(e.to_string()));
+                }
+            }
+        }
+    }
+}
+
+#[cfg(all(test, feature = "tcp-uring", target_os = "linux"))]
+mod tests {
+    use super::*;
+    use crate::handler::Responder;
+    use ironsbe_transport::tcp_uring::UringTcpTransport;
+
+    struct TestHandler;
+    impl MessageHandler for TestHandler {
+        fn on_message(
+            &self,
+            _session_id: u64,
+            _header: &MessageHeader,
+            _data: &[u8],
+            _responder: &dyn Responder,
+        ) {
+        }
+    }
+
+    #[test]
+    fn test_local_server_builder_new() {
+        let builder = LocalServerBuilder::<TestHandler, UringTcpTransport>::new();
+        let _ = builder;
+    }
+
+    #[test]
+    fn test_local_server_builder_default() {
+        let builder = LocalServerBuilder::<TestHandler, UringTcpTransport>::default();
+        let _ = builder;
+    }
+
+    #[test]
+    fn test_local_server_builder_bind() {
+        let addr: SocketAddr = "127.0.0.1:8080".parse().expect("test addr");
+        let builder = LocalServerBuilder::<TestHandler, UringTcpTransport>::new().bind(addr);
+        let _ = builder;
+    }
+
+    #[test]
+    fn test_local_server_builder_max_connections() {
+        let builder =
+            LocalServerBuilder::<TestHandler, UringTcpTransport>::new().max_connections(500);
+        let _ = builder;
+    }
+
+    #[test]
+    fn test_local_server_builder_channel_capacity() {
+        let builder =
+            LocalServerBuilder::<TestHandler, UringTcpTransport>::new().channel_capacity(8192);
+        let _ = builder;
+    }
+
+    #[test]
+    fn test_local_server_builder_build() {
+        let (_server, _handle) = LocalServerBuilder::<TestHandler, UringTcpTransport>::new()
+            .handler(TestHandler)
+            .build();
+    }
+}

--- a/ironsbe-server/tests/local_server_uring.rs
+++ b/ironsbe-server/tests/local_server_uring.rs
@@ -1,0 +1,107 @@
+//! Linux-only end-to-end test for the [`LocalServer`] / [`LocalClient`]
+//! types running on top of the io_uring backend.
+//!
+//! Drives the whole stack inside a single `tokio_uring::start` block:
+//!
+//! 1. Build a [`LocalServer`] with an echo handler.
+//! 2. Spawn it on the local set with `spawn_local`.
+//! 3. Build a [`LocalClient`] targeting the bound port and spawn its
+//!    `run()` loop.
+//! 4. Send an SBE message via the [`ClientHandle`], wait for the echo,
+//!    assert payload equality.
+//! 5. Tear everything down cleanly.
+
+#![cfg(all(feature = "tcp-uring", target_os = "linux"))]
+
+use ironsbe_client::{ClientEvent, LocalClientBuilder};
+use ironsbe_core::header::MessageHeader;
+use ironsbe_server::{LocalServerBuilder, MessageHandler, Responder};
+use ironsbe_transport::tcp_uring::{UringServerConfig, UringTcpTransport};
+use std::net::SocketAddr;
+use std::time::Duration;
+
+const PAYLOAD: &[u8] = b"hello-uring-server";
+
+struct EchoHandler;
+
+impl MessageHandler for EchoHandler {
+    fn on_message(
+        &self,
+        _session_id: u64,
+        _header: &MessageHeader,
+        buffer: &[u8],
+        responder: &dyn Responder,
+    ) {
+        let _ = responder.send(buffer);
+    }
+}
+
+#[test]
+fn test_local_server_local_client_round_trip_uring() {
+    tokio_uring::start(async {
+        // The LocalServer takes ownership of the bind step and does not
+        // currently expose the bound socket back to the caller, so we
+        // pre-probe an ephemeral port via a stdlib listener and re-use
+        // it for the server.  There's a small race window but for a
+        // single-threaded test on loopback it is acceptable.
+        let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("probe bind");
+        let port = probe.local_addr().expect("probe addr").port();
+        drop(probe);
+
+        let server_addr: SocketAddr = format!("127.0.0.1:{port}").parse().expect("addr");
+        let server_cfg = UringServerConfig::new(server_addr);
+        let (mut server, _server_handle) =
+            LocalServerBuilder::<EchoHandler, UringTcpTransport>::new()
+                .bind_config(server_cfg)
+                .handler(EchoHandler)
+                .build();
+
+        // 2. Run the server on the local set.
+        let _server_task = tokio::task::spawn_local(async move {
+            let _ = server.run().await;
+        });
+
+        // Give the server a moment to bind before connecting.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // 3. Build the client and run its driver.
+        let (mut client, mut client_handle) =
+            LocalClientBuilder::<UringTcpTransport>::new(server_addr)
+                .connect_timeout(Duration::from_secs(2))
+                .max_reconnect_attempts(2)
+                .build();
+        let _client_task = tokio::task::spawn_local(async move {
+            let _ = client.run().await;
+        });
+
+        // Wait for connection establishment.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // 4. Build a tiny SBE message and send it.
+        let mut framed = Vec::with_capacity(MessageHeader::ENCODED_LENGTH + PAYLOAD.len());
+        framed.extend_from_slice(&[0u8; MessageHeader::ENCODED_LENGTH]);
+        framed.extend_from_slice(PAYLOAD);
+        client_handle.send(framed.clone()).expect("send");
+
+        // 5. Drain events until we see the echo (or time out).
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        let mut got_echo = false;
+        while std::time::Instant::now() < deadline {
+            while let Some(event) = client_handle.poll() {
+                if let ClientEvent::Message(bytes) = event
+                    && bytes == framed
+                {
+                    got_echo = true;
+                    break;
+                }
+            }
+            if got_echo {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(got_echo, "did not receive echo within deadline");
+
+        client_handle.disconnect();
+    });
+}

--- a/ironsbe-server/tests/local_server_uring.rs
+++ b/ironsbe-server/tests/local_server_uring.rs
@@ -14,13 +14,15 @@
 #![cfg(all(feature = "tcp-uring", target_os = "linux"))]
 
 use ironsbe_client::{ClientEvent, LocalClientBuilder};
+use ironsbe_core::buffer::{AlignedBuffer, ReadBuffer, WriteBuffer};
 use ironsbe_core::header::MessageHeader;
-use ironsbe_server::{LocalServerBuilder, MessageHandler, Responder};
+use ironsbe_server::{LocalServerBuilder, MessageHandler, Responder, ServerEvent};
 use ironsbe_transport::tcp_uring::{UringServerConfig, UringTcpTransport};
 use std::net::SocketAddr;
 use std::time::Duration;
 
 const PAYLOAD: &[u8] = b"hello-uring-server";
+const TEMPLATE_ID: u16 = 42;
 
 struct EchoHandler;
 
@@ -36,57 +38,80 @@ impl MessageHandler for EchoHandler {
     }
 }
 
+/// Builds a real SBE message: encoded `MessageHeader` + payload.  We
+/// validate the full encode/decode path rather than handing the server
+/// an all-zero header.
+fn build_sbe_message() -> Vec<u8> {
+    let mut buffer = AlignedBuffer::<128>::new();
+    let header = MessageHeader::new(PAYLOAD.len() as u16, TEMPLATE_ID, 1, 1);
+    header.encode(&mut buffer, 0);
+    let header_size = MessageHeader::ENCODED_LENGTH;
+    buffer.as_mut_slice()[header_size..header_size + PAYLOAD.len()].copy_from_slice(PAYLOAD);
+    buffer.as_slice()[..header_size + PAYLOAD.len()].to_vec()
+}
+
 #[test]
 fn test_local_server_local_client_round_trip_uring() {
     tokio_uring::start(async {
-        // The LocalServer takes ownership of the bind step and does not
-        // currently expose the bound socket back to the caller, so we
-        // pre-probe an ephemeral port via a stdlib listener and re-use
-        // it for the server.  There's a small race window but for a
-        // single-threaded test on loopback it is acceptable.
-        let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("probe bind");
-        let port = probe.local_addr().expect("probe addr").port();
-        drop(probe);
-
-        let server_addr: SocketAddr = format!("127.0.0.1:{port}").parse().expect("addr");
-        let server_cfg = UringServerConfig::new(server_addr);
-        let (mut server, _server_handle) =
+        // Bind to port 0 and let the server tell us the effective addr
+        // through the ServerEvent::Listening event — no probe-port race.
+        let bind_addr: SocketAddr = "127.0.0.1:0".parse().expect("addr");
+        let server_cfg = UringServerConfig::new(bind_addr);
+        let (mut server, server_handle) =
             LocalServerBuilder::<EchoHandler, UringTcpTransport>::new()
                 .bind_config(server_cfg)
                 .handler(EchoHandler)
                 .build();
 
-        // 2. Run the server on the local set.
+        // Run the server on the local set.
         let _server_task = tokio::task::spawn_local(async move {
             let _ = server.run().await;
         });
 
-        // Give the server a moment to bind before connecting.
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        // Wait for ServerEvent::Listening so we know the effective addr.
+        let listen_deadline = std::time::Instant::now() + Duration::from_secs(2);
+        let server_addr = loop {
+            assert!(
+                std::time::Instant::now() < listen_deadline,
+                "server did not emit Listening within 2 s"
+            );
+            if let Some(ServerEvent::Listening(addr)) = server_handle.poll_events().next() {
+                break addr;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        };
 
-        // 3. Build the client and run its driver.
-        let (mut client, mut client_handle) =
-            LocalClientBuilder::<UringTcpTransport>::new(server_addr)
-                .connect_timeout(Duration::from_secs(2))
-                .max_reconnect_attempts(2)
-                .build();
+        // Build the client and run its driver.
+        let (client, mut client_handle) = LocalClientBuilder::<UringTcpTransport>::new(server_addr)
+            .connect_timeout(Duration::from_secs(2))
+            .max_reconnect_attempts(2)
+            .build();
+        let mut client = client;
         let _client_task = tokio::task::spawn_local(async move {
             let _ = client.run().await;
         });
 
-        // Wait for connection establishment.
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        // Wait for connection establishment via the Connected event.
+        let connect_deadline = std::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            assert!(
+                std::time::Instant::now() < connect_deadline,
+                "client never connected"
+            );
+            if let Some(ClientEvent::Connected) = client_handle.poll() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
 
-        // 4. Build a tiny SBE message and send it.
-        let mut framed = Vec::with_capacity(MessageHeader::ENCODED_LENGTH + PAYLOAD.len());
-        framed.extend_from_slice(&[0u8; MessageHeader::ENCODED_LENGTH]);
-        framed.extend_from_slice(PAYLOAD);
+        // Build a real SBE message and send it.
+        let framed = build_sbe_message();
         client_handle.send(framed.clone()).expect("send");
 
-        // 5. Drain events until we see the echo (or time out).
-        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        // Drain events until we see the echo (or time out).
+        let echo_deadline = std::time::Instant::now() + Duration::from_secs(2);
         let mut got_echo = false;
-        while std::time::Instant::now() < deadline {
+        while std::time::Instant::now() < echo_deadline {
             while let Some(event) = client_handle.poll() {
                 if let ClientEvent::Message(bytes) = event
                     && bytes == framed

--- a/ironsbe/Cargo.toml
+++ b/ironsbe/Cargo.toml
@@ -36,3 +36,25 @@ path = "examples/client.rs"
 [[example]]
 name = "benchmark_report"
 path = "examples/benchmark_report.rs"
+
+[[example]]
+name = "uring_server"
+path = "examples/uring_server.rs"
+
+[[example]]
+name = "uring_client"
+path = "examples/uring_client.rs"
+
+[features]
+default = []
+# Linux-only io_uring backend.  Forwards to the matching feature in
+# ironsbe-server / ironsbe-client / ironsbe-transport so the
+# uring_server / uring_client examples can opt in.
+tcp-uring = [
+    "ironsbe-server/tcp-uring",
+    "ironsbe-client/tcp-uring",
+    "ironsbe-transport/tcp-uring",
+]
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+tokio-uring = { workspace = true }

--- a/ironsbe/examples/uring_client.rs
+++ b/ironsbe/examples/uring_client.rs
@@ -3,11 +3,10 @@
 //! Run with:
 //!
 //! ```sh
-//! cargo run --example uring_client \
-//!     --features ironsbe-client/tcp-uring,ironsbe-transport/tcp-uring
+//! cargo run -p ironsbe --example uring_client --features tcp-uring
 //! ```
 //!
-//! Pair with `cargo run --example uring_server --features ...`.
+//! Pair with `cargo run -p ironsbe --example uring_server --features tcp-uring`.
 //!
 //! On non-Linux platforms (or without the `tcp-uring` feature) the binary
 //! still compiles but `main` exits early with a clear message.

--- a/ironsbe/examples/uring_client.rs
+++ b/ironsbe/examples/uring_client.rs
@@ -1,0 +1,104 @@
+//! Example IronSBE client running on the Linux io_uring backend.
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo run --example uring_client \
+//!     --features ironsbe-client/tcp-uring,ironsbe-transport/tcp-uring
+//! ```
+//!
+//! Pair with `cargo run --example uring_server --features ...`.
+//!
+//! On non-Linux platforms (or without the `tcp-uring` feature) the binary
+//! still compiles but `main` exits early with a clear message.
+
+#[cfg(all(feature = "tcp-uring", target_os = "linux"))]
+mod imp {
+    use ironsbe_client::{ClientEvent, LocalClientBuilder};
+    use ironsbe_core::buffer::{AlignedBuffer, ReadBuffer, WriteBuffer};
+    use ironsbe_core::header::MessageHeader;
+    use ironsbe_transport::tcp_uring::UringTcpTransport;
+    use std::net::SocketAddr;
+    use std::time::Duration;
+
+    /// Builds a tiny SBE message with the given template ID and payload.
+    fn create_message(template_id: u16, payload: &[u8]) -> Vec<u8> {
+        let mut buffer = AlignedBuffer::<256>::new();
+        let header = MessageHeader::new(payload.len() as u16, template_id, 1, 1);
+        header.encode(&mut buffer, 0);
+        let header_size = MessageHeader::ENCODED_LENGTH;
+        buffer.as_mut_slice()[header_size..header_size + payload.len()].copy_from_slice(payload);
+        buffer.as_slice()[..header_size + payload.len()].to_vec()
+    }
+
+    pub(crate) fn run() -> Result<(), Box<dyn std::error::Error>> {
+        tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .init();
+
+        let addr: SocketAddr = "127.0.0.1:9000".parse()?;
+        println!("Connecting IronSBE uring client to {addr}");
+
+        let (client, mut handle) = LocalClientBuilder::<UringTcpTransport>::new(addr)
+            .connect_timeout(Duration::from_secs(5))
+            .max_reconnect_attempts(3)
+            .build();
+        let mut client = client;
+
+        // The whole client lives inside the single-threaded uring reactor.
+        tokio_uring::start(async move {
+            // Spawn the client driver on the local task set.
+            let driver = tokio::task::spawn_local(async move {
+                if let Err(e) = client.run().await {
+                    eprintln!("[uring client] driver error: {e:?}");
+                }
+            });
+
+            // Give the driver a moment to connect.
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            // Send a few messages and read the echoes back.
+            for i in 0..5u32 {
+                let payload = format!("hello-{i}");
+                let msg = create_message(1, payload.as_bytes());
+                if let Err(e) = handle.send(msg) {
+                    eprintln!("[uring client] send #{i} failed: {e:?}");
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                while let Some(event) = handle.poll() {
+                    match event {
+                        ClientEvent::Message(bytes) => {
+                            println!("[uring client] echo received ({} bytes)", bytes.len());
+                        }
+                        ClientEvent::Connected => println!("[uring client] connected"),
+                        ClientEvent::Disconnected => {
+                            println!("[uring client] disconnected");
+                        }
+                        ClientEvent::Error(msg) => {
+                            eprintln!("[uring client] error event: {msg}");
+                        }
+                    }
+                }
+            }
+
+            handle.disconnect();
+            let _ = driver.await;
+        });
+
+        Ok(())
+    }
+}
+
+#[cfg(all(feature = "tcp-uring", target_os = "linux"))]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    imp::run()
+}
+
+#[cfg(not(all(feature = "tcp-uring", target_os = "linux")))]
+fn main() {
+    eprintln!(
+        "uring_client example requires --features tcp-uring on Linux \
+         (kernel >= 5.10).  This build does not have it enabled."
+    );
+}

--- a/ironsbe/examples/uring_server.rs
+++ b/ironsbe/examples/uring_server.rs
@@ -1,0 +1,83 @@
+//! Example IronSBE server running on the Linux io_uring backend.
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo run --example uring_server \
+//!     --features ironsbe-server/tcp-uring,ironsbe-transport/tcp-uring
+//! ```
+//!
+//! On non-Linux platforms (or without the `tcp-uring` feature) the binary
+//! still compiles but `main` exits early with a clear message — that
+//! keeps `cargo build --examples` working everywhere.
+
+#[cfg(all(feature = "tcp-uring", target_os = "linux"))]
+mod imp {
+    use ironsbe_core::header::MessageHeader;
+    use ironsbe_server::{LocalServerBuilder, MessageHandler, Responder, ServerError};
+    use ironsbe_transport::tcp_uring::UringTcpTransport;
+    use std::net::SocketAddr;
+
+    /// Echoes every received SBE message straight back to the sender.
+    pub(crate) struct EchoHandler;
+
+    impl MessageHandler for EchoHandler {
+        fn on_message(
+            &self,
+            session_id: u64,
+            _header: &MessageHeader,
+            buffer: &[u8],
+            responder: &dyn Responder,
+        ) {
+            if let Err(e) = responder.send(buffer) {
+                eprintln!("[uring server] session {session_id} echo failed: {e:?}");
+            }
+        }
+
+        fn on_session_start(&self, session_id: u64) {
+            println!("[uring server] session {session_id} connected");
+        }
+
+        fn on_session_end(&self, session_id: u64) {
+            println!("[uring server] session {session_id} disconnected");
+        }
+    }
+
+    pub(crate) fn run() -> Result<(), ServerError> {
+        tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .init();
+
+        let addr: SocketAddr = "127.0.0.1:9000"
+            .parse()
+            .expect("hardcoded example addr is valid");
+
+        let (mut server, _handle) = LocalServerBuilder::<EchoHandler, UringTcpTransport>::new()
+            .bind(addr)
+            .handler(EchoHandler)
+            .max_connections(64)
+            .build();
+
+        println!("Starting IronSBE uring server on {addr}");
+        println!("Press Ctrl+C to stop");
+
+        // `tokio_uring::start` installs a single-threaded reactor with a
+        // `LocalSet` so the server's `spawn_local`-driven session loop
+        // can run alongside `!Send` uring connections.
+        tokio_uring::start(async move { server.run().await })?;
+        Ok(())
+    }
+}
+
+#[cfg(all(feature = "tcp-uring", target_os = "linux"))]
+fn main() -> Result<(), ironsbe_server::ServerError> {
+    imp::run()
+}
+
+#[cfg(not(all(feature = "tcp-uring", target_os = "linux")))]
+fn main() {
+    eprintln!(
+        "uring_server example requires --features tcp-uring on Linux \
+         (kernel >= 5.10).  This build does not have it enabled."
+    );
+}

--- a/ironsbe/examples/uring_server.rs
+++ b/ironsbe/examples/uring_server.rs
@@ -3,9 +3,12 @@
 //! Run with:
 //!
 //! ```sh
-//! cargo run --example uring_server \
-//!     --features ironsbe-server/tcp-uring,ironsbe-transport/tcp-uring
+//! cargo run -p ironsbe --example uring_server --features tcp-uring
 //! ```
+//!
+//! `tcp-uring` here is the forwarding feature on the `ironsbe` umbrella
+//! crate, which transitively enables it on `ironsbe-server`,
+//! `ironsbe-client` and `ironsbe-transport`.
 //!
 //! On non-Linux platforms (or without the `tcp-uring` feature) the binary
 //! still compiles but `main` exits early with a clear message — that


### PR DESCRIPTION
## Summary

Wires the high-level `ironsbe-server` / `ironsbe-client` engines onto the Linux io_uring backend introduced in #15. Closes #26.

### What's in this PR

- **`LocalServerBuilder` / `LocalServer`** in `ironsbe-server`, parallel to the existing multi-threaded `Server` but generic over the `LocalTransport` trait family added in #15. Per-session futures are spawned via `tokio::task::spawn_local` so they can hold `!Send` connections, and `run()` must be polled inside a Tokio `LocalSet` (typically `tokio_uring::start`).
- **`LocalClientBuilder` / `LocalClient`** in `ironsbe-client` with the same shape, sharing `ClientHandle` / `ClientCommand` / `ClientEvent` with the multi-threaded version via a new `pub(crate)` constructor on `ClientHandle`.
- **`tcp-uring` feature** forwarded from `ironsbe-server`, `ironsbe-client` and the `ironsbe` umbrella crate so feature selection is uniform across the workspace.
- **`examples/uring_server.rs` + `examples/uring_client.rs`** gated to `cfg(all(feature = "tcp-uring", target_os = "linux"))` with a stub `main()` on other platforms so `cargo build --examples` keeps working everywhere.
- **`ironsbe-bench/benches/transport_round_trip.rs`** — criterion benchmark comparing `tcp-tokio` vs `tcp-uring` round-trip latency for a 64-byte SBE payload over a persistent connection.
- **`ironsbe-server/tests/local_server_uring.rs`** — end-to-end Linux-only integration test that drives both `LocalServer` and `LocalClient` inside a single `tokio_uring::start` block and asserts an SBE round-trip.
- **Docs**: new server-integration section in `docs/transport-backends.md` plus bench commands and a placeholder for the numbers.

### Why a parallel `LocalServer` / `LocalClient`

The existing `Server<H, T: Transport>` requires `T::Connection: Send + 'static` because it spawns one `tokio::spawn` task per session. `tokio-uring`'s connection types contain `Rc<...>` internally (single-threaded by design) and so are `!Send`.  The two natural responses are:

1. Relax the `Send` bound on the existing types — would break the multi-threaded `tcp-tokio` server.
2. Add a parallel type generic over `LocalTransport`. Picked this.

The two server types share `MessageHandler`, `ServerHandle`, the command/event enums, and ~80% of the session loop code. The split only diverges on the spawn primitive (`tokio::spawn` vs `spawn_local`) and the trait bounds.

### Multi-worker scaling

Out of scope for this PR. The single-thread `LocalServer` is enough to validate the integration end-to-end and produce the bench numbers; a multi-worker `SO_REUSEPORT` topology can land later if the benches justify it.

### Bench numbers

**TBD pending hardware run.** I cannot run the io_uring path on macOS, so the numbers below need to be filled in on a Linux ≥ 5.10 box before merge:

| Backend     | p50 | p99 | p99.9 | Throughput |
|-------------|-----|-----|-------|------------|
| `tcp-tokio` | TBD | TBD | TBD   | TBD        |
| `tcp-uring` | TBD | TBD | TBD   | TBD        |

To run:

```sh
cargo bench -p ironsbe-bench --bench transport_round_trip --features tcp-uring
```

### Test plan

- [x] `cargo check --all-features` on macOS (full workspace, all features)
- [x] `cargo check --all-targets` on macOS (examples + tests + benches gated out for the uring path)
- [x] `cargo check -p ironsbe-server -p ironsbe-client --target x86_64-unknown-linux-gnu --no-default-features --features tcp-tokio,tcp-uring` (cross-compile to Linux)
- [x] `cargo check -p ironsbe-server --tests --target x86_64-unknown-linux-gnu --no-default-features --features tcp-tokio,tcp-uring` (Linux integration test compiles)
- [x] `cargo check -p ironsbe --target x86_64-unknown-linux-gnu --features tcp-uring --examples` (Linux examples compile)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `make pre-push`
- [ ] CI Linux runners verify the full uring-feature build path
- [ ] Hardware run of `transport_round_trip` and update of the table above + `docs/transport-backends.md` (manual)

### Out of scope (not blocking merge)

- Multi-worker `SO_REUSEPORT` LocalServer scaling.
- Hardware bench run (will be done by a follow-up commit on this branch before merge, or in a separate PR).