### PR TITLE
M2 #28: AF_XDP datapath via xsk-rs + operational docs

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update && sudo apt-get install -y make pkg-config
+          sudo apt-get update && sudo apt-get install -y make pkg-config libelf-dev zlib1g-dev libpcap-dev clang m4
 
       - name: Install Tarpaulin
         run: cargo install cargo-tarpaulin

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
         
       - name: Install dependencies
         run: |
-          sudo apt-get update && sudo apt-get install -y make pkg-config
+          sudo apt-get update && sudo apt-get install -y make pkg-config libelf-dev zlib1g-dev libpcap-dev clang m4
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update && sudo apt-get install -y make pkg-config build-essential
+          sudo apt-get update && sudo apt-get install -y make pkg-config build-essential libelf-dev zlib1g-dev libpcap-dev clang m4
 
       - name: Check semver for ironsbe-core
         uses: obi1kenobi/cargo-semver-checks-action@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update && sudo apt-get install -y make pkg-config
+          sudo apt-get update && sudo apt-get install -y make pkg-config libelf-dev zlib1g-dev libpcap-dev clang m4
 
       - name: Run tests
         run: make test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ tokio-util = { version = "0.7", features = ["codec"] }
 socket2 = "0.5"
 tokio-uring = "0.5"
 smoltcp = { version = "0.12", default-features = false, features = ["std", "medium-ethernet", "proto-ipv4", "socket-tcp"] }
+xsk-rs = "0.6"
 etherparse = "0.18"
 futures = "0.3"
 async-trait = "0.1"

--- a/docs/transport-backends.md
+++ b/docs/transport-backends.md
@@ -350,25 +350,41 @@ parse helpers and `etherparse`-based Ethernet/IPv4/UDP builders.  All
 parsers are pure functions returning `Result<_, FrameError>` and have
 unit tests that run on every host.
 
-### Scope of the current PR
+### AF_XDP datapath (`xdp` feature)
 
-This first PR ships the **pure-Rust pieces only** (`xdp-stacks` feature):
-frame parsers, the `XdpStack` trait, `UdpStack` and `SmoltcpStack`, all
-covered by ~15 unit tests that run on macOS / Linux / Windows.
+The `xdp` cargo feature brings in `xsk-rs` and the actual AF_XDP
+datapath layer that ferries frames between the kernel rx/tx/fill/
+completion rings and the `XdpStack` trait above.  This feature is
+Linux-only; on other platforms the flag compiles the pure-Rust stacks
+but not the datapath.
 
-The Linux-only `xdp` feature that brings in `xsk-rs` and the actual
-AF_XDP datapath is tracked separately in the follow-up issue, alongside
-the server integration (`ironsbe-server` worker-per-queue, core
-pinning), examples, and the benchmark suite that compares `tcp-tokio`,
-`tcp-uring` and `xdp` on real hardware.
+The datapath is driven via `Datapath::poll_once`, which in a single
+call: reclaims completed tx descriptors, pulls inbound frames from the
+rx ring (calling `XdpStack::on_rx` per frame), flushes stack timers,
+and submits any outbound frames the stack produced.
 
-### Operational checklist (will move to the follow-up PR)
+```sh
+# Build the full xdp backend on Linux:
+cargo build -p ironsbe-transport --no-default-features --features xdp
+```
 
-The full operational guide — kernel ≥ 5.11, capabilities
-(`CAP_NET_ADMIN` / `CAP_NET_RAW` / `CAP_BPF`), `ethtool -N` queue
-steering recipe, copy-mode vs zero-copy fallback, driver matrix — will
-be added in the follow-up PR that lands the datapath, since it depends
-on the actual `xdp` cargo feature being usable.
+### Operational checklist
+
+- **Kernel**: Linux ≥ 5.11 (required by `xsk-rs 0.6` / `libxdp`).
+- **Capabilities**: `CAP_NET_ADMIN`, `CAP_BPF` (or root).
+- **Build deps**: `libelf-dev`, `zlib1g-dev`, `libpcap-dev`, `clang`,
+  `m4` (for `libbpf-sys` / `libxdp-sys` build scripts).
+- **NIC driver**: must support XDP (`igc`, `i40e`, `ice`, `mlx5`,
+  `ixgbe`, `virtio_net` copy-mode).  Check with
+  `ethtool -i <iface> | grep driver`.
+- **Queue steering** (for isolating XDP traffic):
+  ```sh
+  # Steer TCP port 9000 to queue 4:
+  ethtool -N eth0 flow-type tcp4 dst-port 9000 action 4
+  ```
+- **Copy vs zero-copy**: AF_XDP defaults to copy mode.  Zero-copy
+  requires driver support and `XSK_FORCE_COPY=0` (not yet exposed by
+  the datapath module; planned for a follow-up).
 
 ## Adding a new backend
 

--- a/ironsbe-client/Cargo.toml
+++ b/ironsbe-client/Cargo.toml
@@ -16,6 +16,7 @@ tcp-tokio = ["ironsbe-transport/tcp-tokio"]
 # Linux-only io_uring backend.  Enables the LocalClient and integration
 # tests against the matching transport feature.
 tcp-uring = ["ironsbe-transport/tcp-uring"]
+xdp = ["ironsbe-transport/xdp"]
 
 [dependencies]
 ironsbe-core = { workspace = true }

--- a/ironsbe-server/Cargo.toml
+++ b/ironsbe-server/Cargo.toml
@@ -16,6 +16,7 @@ tcp-tokio = ["ironsbe-transport/tcp-tokio"]
 # Linux-only io_uring backend.  Brings in the LocalServer integration
 # tests and gates them on Linux + the matching transport feature.
 tcp-uring = ["ironsbe-transport/tcp-uring"]
+xdp = ["ironsbe-transport/xdp"]
 
 [dependencies]
 ironsbe-core = { workspace = true }

--- a/ironsbe-server/src/builder.rs
+++ b/ironsbe-server/src/builder.rs
@@ -289,18 +289,19 @@ where
         handler.on_session_start(session_id);
         let _ = event_tx.try_send(ServerEvent::SessionCreated(session_id, addr));
 
-        // Spawn connection handler task
+        // Spawn connection handler task.  The span gives every log
+        // line inside the session the `sbe_session{session_id=N}:`
+        // prefix so operators can correlate messages per peer.
+        let span = tracing::info_span!("sbe_session", session_id, %addr);
         tokio::spawn(async move {
-            tracing::info!("Session {} connected from {}", session_id, addr);
+            let _guard = span.enter();
+            tracing::info!("connected");
 
             if let Err(e) = handle_session(session_id, conn, handler.as_ref()).await {
-                tracing::error!("Session {} error: {:?}", session_id, e);
+                tracing::error!(error = %e, "session error");
             }
 
-            // When done, notify and ask the run loop to release the
-            // SessionManager slot.
-            // When done, notify and ask the run loop to release the
-            // SessionManager slot.
+            tracing::info!("disconnected");
             handler.on_session_end(session_id);
             let _ = event_tx.try_send(ServerEvent::SessionClosed(session_id));
             let _ = cmd_tx.try_send(ServerCommand::CloseSession(session_id));
@@ -450,11 +451,10 @@ where
                         }
                     }
                     Ok(None) => {
-                        tracing::info!("Session {} disconnected", session_id);
                         return Ok(());
                     }
                     Err(e) => {
-                        tracing::error!("Session {} read error: {}", session_id, e);
+                        tracing::error!(error = %e, "read error");
                         return Err(std::io::Error::other(e));
                     }
                 }
@@ -463,7 +463,7 @@ where
             // Send outgoing messages
             Some(msg) = rx.recv() => {
                 if let Err(e) = conn.send(&msg).await {
-                    tracing::error!("Session {} write error: {}", session_id, e);
+                    tracing::error!(error = %e, "write error");
                     return Err(std::io::Error::other(e));
                 }
             }

--- a/ironsbe-server/src/local_builder.rs
+++ b/ironsbe-server/src/local_builder.rs
@@ -234,15 +234,19 @@ where
         let _ = event_tx.try_send(ServerEvent::SessionCreated(session_id, addr));
 
         // `spawn_local` keeps the future on the current single-threaded
-        // runtime, satisfying the `!Send` connection bound.
+        // runtime, satisfying the `!Send` connection bound.  The span
+        // gives every log line inside the session the
+        // `sbe_session{session_id=N}:` prefix.
+        let span = tracing::info_span!("sbe_session", session_id, %addr);
         tokio::task::spawn_local(async move {
-            tracing::info!("Local session {} connected from {}", session_id, addr);
+            let _guard = span.enter();
+            tracing::info!("connected");
             if let Err(e) = handle_local_session(session_id, conn, handler.as_ref()).await {
-                tracing::error!("Local session {} error: {:?}", session_id, e);
+                tracing::error!(error = %e, "session error");
             }
+            tracing::info!("disconnected");
             handler.on_session_end(session_id);
             let _ = event_tx.try_send(ServerEvent::SessionClosed(session_id));
-            // Ask the run loop to release the SessionManager slot.
             let _ = cmd_tx.try_send(ServerCommand::CloseSession(session_id));
             cmd_notify.notify_one();
         });
@@ -313,11 +317,10 @@ where
                         }
                     }
                     Ok(None) => {
-                        tracing::info!("Local session {} disconnected", session_id);
                         return Ok(());
                     }
                     Err(e) => {
-                        tracing::error!("Local session {} read error: {}", session_id, e);
+                        tracing::error!(error = %e, "read error");
                         return Err(std::io::Error::other(e.to_string()));
                     }
                 }
@@ -325,7 +328,7 @@ where
 
             Some(msg) = rx.recv() => {
                 if let Err(e) = conn.send(&msg).await {
-                    tracing::error!("Local session {} write error: {}", session_id, e);
+                    tracing::error!(error = %e, "write error");
                     return Err(std::io::Error::other(e.to_string()));
                 }
             }

--- a/ironsbe-transport/Cargo.toml
+++ b/ironsbe-transport/Cargo.toml
@@ -22,6 +22,10 @@ tcp-uring = ["dep:tokio-uring"]
 # real NIC queue is landed in a follow-up PR alongside the server
 # integration and benchmarks (it requires hardware to validate).
 xdp-stacks = ["dep:smoltcp", "dep:etherparse"]
+# Full AF_XDP backend.  Includes the pure-Rust stacks above plus the
+# `xsk-rs`-based datapath that binds to a real NIC queue.  Linux-only
+# (xsk-rs is target-conditional in the deps below).
+xdp = ["xdp-stacks", "dep:xsk-rs"]
 
 [dependencies]
 ironsbe-core = { workspace = true }
@@ -46,6 +50,7 @@ optional = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 tokio-uring = { workspace = true, optional = true }
+xsk-rs = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/ironsbe-transport/src/xdp/datapath.rs
+++ b/ironsbe-transport/src/xdp/datapath.rs
@@ -1,0 +1,256 @@
+//! AF_XDP datapath wrapper around `xsk-rs` (Linux + `xdp` feature only).
+//!
+//! This module owns the UMEM, the rx/tx/fill/completion queues and the
+//! polling loop that drives an [`super::stack::XdpStack`] above the wire.
+//!
+//! # Safety
+//!
+//! `xsk-rs` requires `unsafe` to create a socket (shared UMEM semantics)
+//! and to access UMEM-backed frame data.  All `unsafe` blocks in this
+//! module are documented with `// SAFETY:` comments.
+
+use crate::xdp::stack::{FrameTxQueue, XdpStack};
+use std::io;
+use xsk_rs::config::{Interface, SocketConfig, UmemConfig};
+use xsk_rs::socket::{RxQueue, TxQueue};
+use xsk_rs::umem::{CompQueue, FillQueue, Umem};
+use xsk_rs::umem::frame::FrameDesc;
+
+/// Configuration for the AF_XDP datapath.
+#[derive(Debug, Clone)]
+pub struct DatapathConfig {
+    /// Interface name (`eth0`, `lo`, …).
+    pub if_name: String,
+    /// NIC queue id this datapath is bound to.
+    pub queue_id: u32,
+    /// Number of UMEM frames to allocate.  Must be a power of two.
+    pub frame_count: u32,
+    /// Per-frame size in bytes.  Must be a power of two ≥ 2048.
+    pub frame_size: u32,
+}
+
+impl DatapathConfig {
+    /// Creates a new datapath config with conservative defaults.
+    #[must_use]
+    pub fn new(if_name: impl Into<String>, queue_id: u32) -> Self {
+        Self {
+            if_name: if_name.into(),
+            queue_id,
+            frame_count: 4096,
+            frame_size: 4096,
+        }
+    }
+
+    /// Sets the number of UMEM frames.
+    #[must_use]
+    pub fn frame_count(mut self, count: u32) -> Self {
+        self.frame_count = count;
+        self
+    }
+
+    /// Sets the per-frame size.
+    #[must_use]
+    pub fn frame_size(mut self, size: u32) -> Self {
+        self.frame_size = size;
+        self
+    }
+}
+
+/// AF_XDP datapath bound to a single `(interface, queue)` pair.
+///
+/// Holds the UMEM, the four ring queues, and the pool of frame
+/// descriptors used to ferry packets between the kernel and userspace.
+pub struct Datapath {
+    umem: Umem,
+    fill_q: FillQueue,
+    comp_q: CompQueue,
+    rx_q: RxQueue,
+    tx_q: TxQueue,
+    /// Pool of free frame descriptors that can be submitted to the fill
+    /// queue (rx) or used for tx.  When a frame is consumed from the rx
+    /// ring its descriptor moves here; when a frame is submitted to the
+    /// tx ring its descriptor is taken from here.
+    frame_descs: Vec<FrameDesc>,
+}
+
+impl Datapath {
+    /// Binds an AF_XDP socket to the configured interface/queue.
+    ///
+    /// Requires `CAP_NET_ADMIN` and `CAP_BPF` (or root).
+    ///
+    /// # Errors
+    /// Returns an `io::Error` if the kernel rejects the bind (missing
+    /// capabilities, bad interface name, queue out of range, …).
+    ///
+    /// # Safety contract
+    /// The caller guarantees that no other `Datapath` is bound to the
+    /// same `(if_name, queue_id)` pair with the same `Umem`, or that
+    /// the `XSK_LIBXDP_FLAGS_INHIBIT_PROG_LOAD` flag is set in the
+    /// socket config if so.  In practice this means "one `Datapath`
+    /// per queue per process".
+    pub fn bind(config: &DatapathConfig) -> io::Result<Self> {
+        let umem_config = UmemConfig::builder(
+            config.frame_count.try_into().map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "frame_count must be > 0",
+                )
+            })?,
+            config.frame_size.try_into().map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "frame_size must be > 0",
+                )
+            })?,
+        )
+        .build()
+        .map_err(|e| io::Error::other(format!("umem config: {e}")))?;
+
+        let (umem, mut frame_descs) = Umem::new(
+            umem_config,
+            config.frame_count.try_into().map_err(|_| {
+                io::Error::new(io::ErrorKind::InvalidInput, "frame_count must be > 0")
+            })?,
+            false, // no huge pages
+        )
+        .map_err(|e| io::Error::other(format!("umem create: {e}")))?;
+
+        let socket_config = SocketConfig::default();
+        let interface = Interface::new(config.if_name.as_str())
+            .map_err(|e| io::Error::other(format!("interface: {e}")))?;
+
+        // SAFETY: We are the only Datapath binding to this
+        // (if_name, queue_id) pair — the caller guarantees this per
+        // the doc contract.
+        let (tx_q, rx_q, fq_cq) = unsafe {
+            xsk_rs::socket::Socket::new(
+                socket_config,
+                &umem,
+                &interface,
+                config.queue_id,
+            )
+        }
+        .map_err(|e| io::Error::other(format!("xsk socket create: {e}")))?;
+
+        let (mut fill_q, comp_q) = fq_cq.ok_or_else(|| {
+            io::Error::other("xsk-rs did not return fill/completion queues")
+        })?;
+
+        // Submit half the frames to the fill queue so the kernel has
+        // somewhere to write inbound packets.  Keep the other half for
+        // tx.
+        let half = frame_descs.len() / 2;
+        let fill_frames: Vec<FrameDesc> = frame_descs.drain(..half).collect();
+
+        // SAFETY: frame descriptors are valid UMEM offsets produced by
+        // Umem::new and have not been submitted to any other queue.
+        unsafe {
+            fill_q.produce(&fill_frames);
+        }
+
+        Ok(Self {
+            umem,
+            fill_q,
+            comp_q,
+            rx_q,
+            tx_q,
+            frame_descs,
+        })
+    }
+
+    /// Drives one poll round of the AF_XDP socket.
+    ///
+    /// 1. Reclaims completed tx descriptors from the completion queue.
+    /// 2. Pulls inbound frames from the rx queue and hands them to the
+    ///    stack via [`XdpStack::on_rx`].
+    /// 3. Calls [`XdpStack::poll_timers`].
+    /// 4. Submits any frames the stack produced into the tx queue.
+    /// 5. Re-fills the fill queue with reclaimed descriptors.
+    ///
+    /// Returns the number of inbound frames processed.
+    ///
+    /// # Errors
+    /// Returns an `io::Error` if any ring operation fails.
+    pub fn poll_once<S: XdpStack>(&mut self, stack: &mut S) -> io::Result<usize>
+    where
+        S::Error: std::fmt::Display,
+    {
+        // 1. Reclaim completed tx descriptors so we can reuse them.
+        let mut comp_descs = Vec::with_capacity(64);
+        let n_comp = self.comp_q.consume(&mut comp_descs);
+        for desc in comp_descs.iter().take(n_comp) {
+            self.frame_descs.push(*desc);
+        }
+
+        // 2. Pull inbound frames from the rx ring.
+        let mut rx_descs = Vec::with_capacity(64);
+        let n_rx = self.rx_q.consume(&mut rx_descs);
+        let mut tx_buf: Vec<Vec<u8>> = Vec::new();
+        let mut processed = 0usize;
+
+        for desc in rx_descs.iter().take(n_rx) {
+            // SAFETY: the descriptor was just returned by the rx ring
+            // and the backing UMEM slice is valid for the duration of
+            // this loop iteration.  We copy the frame data out before
+            // returning the descriptor to the fill queue.
+            let data = unsafe { self.umem.data(desc) };
+            let frame_bytes = data.contents();
+
+            let mut q = FrameTxQueue::new(&mut tx_buf);
+            stack
+                .on_rx(frame_bytes, &mut q)
+                .map_err(|e| io::Error::other(e.to_string()))?;
+            processed += 1;
+        }
+
+        // Return rx descriptors to the fill queue so the kernel can
+        // reuse them.
+        if n_rx > 0 {
+            // SAFETY: descriptors were consumed from the rx ring and
+            // are no longer referenced by the kernel.
+            unsafe {
+                self.fill_q.produce(&rx_descs[..n_rx]);
+            }
+        }
+
+        // 3. Let the stack flush timers.
+        {
+            let mut q = FrameTxQueue::new(&mut tx_buf);
+            stack
+                .poll_timers(&mut q)
+                .map_err(|e| io::Error::other(e.to_string()))?;
+        }
+
+        // 4. Submit pending tx frames.
+        for frame_data in &tx_buf {
+            if let Some(mut desc) = self.frame_descs.pop() {
+                // SAFETY: `desc` is a valid free descriptor from our
+                // pool, and `data_mut` gives exclusive access to its
+                // UMEM-backed buffer.
+                let data_mut = unsafe { self.umem.data_mut(&mut desc) };
+                let buf = data_mut.contents_mut();
+                let len = frame_data.len().min(buf.len());
+                buf[..len].copy_from_slice(&frame_data[..len]);
+                // Update the descriptor's data length.
+                desc.lengths_mut().set_data(len);
+
+                // SAFETY: we just wrote valid data into the descriptor's
+                // UMEM region, and the descriptor has not been submitted
+                // to any other queue.
+                unsafe {
+                    self.tx_q.produce_and_wakeup(&[desc])
+                        .map_err(|e| io::Error::other(format!("tx produce: {e}")))?;
+                }
+            } else {
+                tracing::warn!("xdp: no free tx descriptors, dropping outbound frame");
+            }
+        }
+
+        // 5. Wakeup if needed (some drivers require explicit kicks).
+        if self.tx_q.needs_wakeup() {
+            self.tx_q.wakeup()?;
+        }
+
+        Ok(processed)
+    }
+}

--- a/ironsbe-transport/src/xdp/datapath.rs
+++ b/ironsbe-transport/src/xdp/datapath.rs
@@ -10,11 +10,14 @@
 //! module are documented with `// SAFETY:` comments.
 
 use crate::xdp::stack::{FrameTxQueue, XdpStack};
+use std::ffi::CString;
 use std::io;
+use std::io::Write;
+use std::num::NonZeroU32;
 use xsk_rs::config::{Interface, SocketConfig, UmemConfig};
 use xsk_rs::socket::{RxQueue, TxQueue};
-use xsk_rs::umem::{CompQueue, FillQueue, Umem};
 use xsk_rs::umem::frame::FrameDesc;
+use xsk_rs::umem::{CompQueue, FillQueue, Umem};
 
 /// Configuration for the AF_XDP datapath.
 #[derive(Debug, Clone)]
@@ -23,7 +26,8 @@ pub struct DatapathConfig {
     pub if_name: String,
     /// NIC queue id this datapath is bound to.
     pub queue_id: u32,
-    /// Number of UMEM frames to allocate.  Must be a power of two.
+    /// Number of UMEM frames to allocate.  Must be a power of two and
+    /// non-zero.
     pub frame_count: u32,
     /// Per-frame size in bytes.  Must be a power of two ≥ 2048.
     pub frame_size: u32,
@@ -56,6 +60,9 @@ impl DatapathConfig {
     }
 }
 
+/// Maximum number of descriptors to process per poll round.
+const BATCH_SIZE: usize = 64;
+
 /// AF_XDP datapath bound to a single `(interface, queue)` pair.
 ///
 /// Holds the UMEM, the four ring queues, and the pool of frame
@@ -66,11 +73,15 @@ pub struct Datapath {
     comp_q: CompQueue,
     rx_q: RxQueue,
     tx_q: TxQueue,
-    /// Pool of free frame descriptors that can be submitted to the fill
-    /// queue (rx) or used for tx.  When a frame is consumed from the rx
-    /// ring its descriptor moves here; when a frame is submitted to the
-    /// tx ring its descriptor is taken from here.
-    frame_descs: Vec<FrameDesc>,
+    /// Pool of free frame descriptors.  Rx-consumed descriptors cycle
+    /// back here after their contents have been read; tx descriptors
+    /// are taken from here and returned via the completion queue.
+    free_descs: Vec<FrameDesc>,
+    /// Scratch space for rx consume calls (avoids re-allocating per
+    /// poll round).
+    rx_scratch: Vec<FrameDesc>,
+    /// Scratch space for completion queue consume.
+    comp_scratch: Vec<FrameDesc>,
 }
 
 impl Datapath {
@@ -82,59 +93,38 @@ impl Datapath {
     /// Returns an `io::Error` if the kernel rejects the bind (missing
     /// capabilities, bad interface name, queue out of range, …).
     ///
-    /// # Safety contract
-    /// The caller guarantees that no other `Datapath` is bound to the
-    /// same `(if_name, queue_id)` pair with the same `Umem`, or that
-    /// the `XSK_LIBXDP_FLAGS_INHIBIT_PROG_LOAD` flag is set in the
-    /// socket config if so.  In practice this means "one `Datapath`
-    /// per queue per process".
+    /// # Safety contract (upheld by the caller)
+    /// No other `Datapath` may be bound to the same `(if_name, queue_id)`
+    /// pair with a shared `Umem`, unless
+    /// `XSK_LIBXDP_FLAGS_INHIBIT_PROG_LOAD` is set.  In practice:
+    /// one `Datapath` per queue per process.
     pub fn bind(config: &DatapathConfig) -> io::Result<Self> {
-        let umem_config = UmemConfig::builder(
-            config.frame_count.try_into().map_err(|_| {
-                io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    "frame_count must be > 0",
-                )
-            })?,
-            config.frame_size.try_into().map_err(|_| {
-                io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    "frame_size must be > 0",
-                )
-            })?,
-        )
-        .build()
-        .map_err(|e| io::Error::other(format!("umem config: {e}")))?;
+        let frame_count = NonZeroU32::new(config.frame_count).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "frame_count must be > 0")
+        })?;
 
-        let (umem, mut frame_descs) = Umem::new(
-            umem_config,
-            config.frame_count.try_into().map_err(|_| {
-                io::Error::new(io::ErrorKind::InvalidInput, "frame_count must be > 0")
-            })?,
-            false, // no huge pages
-        )
-        .map_err(|e| io::Error::other(format!("umem create: {e}")))?;
+        let umem_config = UmemConfig::builder()
+            .build()
+            .map_err(|e| io::Error::other(format!("umem config: {e}")))?;
+
+        let (umem, mut frame_descs) = Umem::new(umem_config, frame_count, false)
+            .map_err(|e| io::Error::other(format!("umem create: {e}")))?;
 
         let socket_config = SocketConfig::default();
-        let interface = Interface::new(config.if_name.as_str())
-            .map_err(|e| io::Error::other(format!("interface: {e}")))?;
+        let if_cstr = CString::new(config.if_name.as_str())
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+        let interface = Interface::new(if_cstr);
 
         // SAFETY: We are the only Datapath binding to this
         // (if_name, queue_id) pair — the caller guarantees this per
-        // the doc contract.
+        // the doc contract above.
         let (tx_q, rx_q, fq_cq) = unsafe {
-            xsk_rs::socket::Socket::new(
-                socket_config,
-                &umem,
-                &interface,
-                config.queue_id,
-            )
+            xsk_rs::socket::Socket::new(socket_config, &umem, &interface, config.queue_id)
         }
         .map_err(|e| io::Error::other(format!("xsk socket create: {e}")))?;
 
-        let (mut fill_q, comp_q) = fq_cq.ok_or_else(|| {
-            io::Error::other("xsk-rs did not return fill/completion queues")
-        })?;
+        let (mut fill_q, comp_q) = fq_cq
+            .ok_or_else(|| io::Error::other("xsk-rs did not return fill/completion queues"))?;
 
         // Submit half the frames to the fill queue so the kernel has
         // somewhere to write inbound packets.  Keep the other half for
@@ -154,7 +144,9 @@ impl Datapath {
             comp_q,
             rx_q,
             tx_q,
-            frame_descs,
+            free_descs: frame_descs,
+            rx_scratch: vec![FrameDesc::default(); BATCH_SIZE],
+            comp_scratch: vec![FrameDesc::default(); BATCH_SIZE],
         })
     }
 
@@ -175,24 +167,27 @@ impl Datapath {
     where
         S::Error: std::fmt::Display,
     {
-        // 1. Reclaim completed tx descriptors so we can reuse them.
-        let mut comp_descs = Vec::with_capacity(64);
-        let n_comp = self.comp_q.consume(&mut comp_descs);
-        for desc in comp_descs.iter().take(n_comp) {
-            self.frame_descs.push(*desc);
+        // 1. Reclaim completed tx descriptors.
+        // SAFETY: comp_scratch is pre-allocated with valid default
+        // FrameDescs; consume overwrites them with completed descs.
+        let n_comp = unsafe { self.comp_q.consume(&mut self.comp_scratch) };
+        for desc in self.comp_scratch.iter().take(n_comp) {
+            self.free_descs.push(*desc);
         }
 
         // 2. Pull inbound frames from the rx ring.
-        let mut rx_descs = Vec::with_capacity(64);
-        let n_rx = self.rx_q.consume(&mut rx_descs);
+        // SAFETY: rx_scratch is pre-allocated; consume overwrites with
+        // received descriptors whose UMEM-backed data is valid until
+        // we return them to the fill queue.
+        let n_rx = unsafe { self.rx_q.consume(&mut self.rx_scratch) };
         let mut tx_buf: Vec<Vec<u8>> = Vec::new();
         let mut processed = 0usize;
 
-        for desc in rx_descs.iter().take(n_rx) {
-            // SAFETY: the descriptor was just returned by the rx ring
-            // and the backing UMEM slice is valid for the duration of
-            // this loop iteration.  We copy the frame data out before
-            // returning the descriptor to the fill queue.
+        for i in 0..n_rx {
+            let desc = &self.rx_scratch[i];
+            // SAFETY: descriptor was just returned by the rx ring;
+            // the UMEM slice is valid until we return the desc to
+            // the fill queue below.
             let data = unsafe { self.umem.data(desc) };
             let frame_bytes = data.contents();
 
@@ -203,13 +198,12 @@ impl Datapath {
             processed += 1;
         }
 
-        // Return rx descriptors to the fill queue so the kernel can
-        // reuse them.
+        // Return rx descriptors to the fill queue for kernel reuse.
         if n_rx > 0 {
-            // SAFETY: descriptors were consumed from the rx ring and
-            // are no longer referenced by the kernel.
+            // SAFETY: descriptors were consumed from rx and are no
+            // longer referenced.
             unsafe {
-                self.fill_q.produce(&rx_descs[..n_rx]);
+                self.fill_q.produce(&self.rx_scratch[..n_rx]);
             }
         }
 
@@ -223,22 +217,26 @@ impl Datapath {
 
         // 4. Submit pending tx frames.
         for frame_data in &tx_buf {
-            if let Some(mut desc) = self.frame_descs.pop() {
+            if let Some(mut desc) = self.free_descs.pop() {
                 // SAFETY: `desc` is a valid free descriptor from our
-                // pool, and `data_mut` gives exclusive access to its
-                // UMEM-backed buffer.
-                let data_mut = unsafe { self.umem.data_mut(&mut desc) };
-                let buf = data_mut.contents_mut();
-                let len = frame_data.len().min(buf.len());
-                buf[..len].copy_from_slice(&frame_data[..len]);
-                // Update the descriptor's data length.
-                desc.lengths_mut().set_data(len);
+                // pool; `data_mut` gives exclusive UMEM access.
+                let mut data_mut = unsafe { self.umem.data_mut(&mut desc) };
+                // `cursor()` sets the data length as we write.
+                let mut cursor = data_mut.cursor();
+                if let Err(e) = cursor.write_all(frame_data) {
+                    tracing::warn!("xdp: tx write failed: {e}");
+                    // Return the descriptor to the free pool.
+                    self.free_descs.push(desc);
+                    continue;
+                }
+                drop(cursor);
+                drop(data_mut);
 
-                // SAFETY: we just wrote valid data into the descriptor's
-                // UMEM region, and the descriptor has not been submitted
-                // to any other queue.
+                // SAFETY: we just wrote valid data into the
+                // descriptor's UMEM region.
                 unsafe {
-                    self.tx_q.produce_and_wakeup(&[desc])
+                    self.tx_q
+                        .produce_and_wakeup(&[desc])
                         .map_err(|e| io::Error::other(format!("tx produce: {e}")))?;
                 }
             } else {

--- a/ironsbe-transport/src/xdp/datapath.rs
+++ b/ironsbe-transport/src/xdp/datapath.rs
@@ -218,19 +218,21 @@ impl Datapath {
         // 4. Submit pending tx frames.
         for frame_data in &tx_buf {
             if let Some(mut desc) = self.free_descs.pop() {
-                // SAFETY: `desc` is a valid free descriptor from our
-                // pool; `data_mut` gives exclusive UMEM access.
-                let mut data_mut = unsafe { self.umem.data_mut(&mut desc) };
-                // `cursor()` sets the data length as we write.
-                let mut cursor = data_mut.cursor();
-                if let Err(e) = cursor.write_all(frame_data) {
-                    tracing::warn!("xdp: tx write failed: {e}");
-                    // Return the descriptor to the free pool.
-                    self.free_descs.push(desc);
-                    continue;
+                // Write the frame data into the descriptor's UMEM
+                // region via a scoped block so the mutable borrow on
+                // `desc` ends before we hand it to the tx queue.
+                {
+                    // SAFETY: `desc` is a valid free descriptor from
+                    // our pool; `data_mut` gives exclusive UMEM access.
+                    let mut data_mut = unsafe { self.umem.data_mut(&mut desc) };
+                    // `cursor()` sets the data length as we write.
+                    let mut cursor = data_mut.cursor();
+                    if let Err(e) = cursor.write_all(frame_data) {
+                        tracing::warn!("xdp: tx write failed: {e}");
+                        self.free_descs.push(desc);
+                        continue;
+                    }
                 }
-                drop(cursor);
-                drop(data_mut);
 
                 // SAFETY: we just wrote valid data into the
                 // descriptor's UMEM region.

--- a/ironsbe-transport/src/xdp/mod.rs
+++ b/ironsbe-transport/src/xdp/mod.rs
@@ -19,6 +19,9 @@
 pub mod frames;
 pub mod stack;
 
+#[cfg(all(feature = "xdp", target_os = "linux"))]
+pub mod datapath;
+
 pub use frames::{
     FrameError, MacAddr, ParsedArp, ParsedFrame, ParsedUdp, build_arp_reply, build_udp_ipv4,
     parse_arp, parse_ethernet, parse_ipv4_udp,

--- a/ironsbe/Cargo.toml
+++ b/ironsbe/Cargo.toml
@@ -55,6 +55,11 @@ tcp-uring = [
     "ironsbe-client/tcp-uring",
     "ironsbe-transport/tcp-uring",
 ]
+xdp = [
+    "ironsbe-server/xdp",
+    "ironsbe-client/xdp",
+    "ironsbe-transport/xdp",
+]
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 tokio-uring = { workspace = true }


### PR DESCRIPTION
## Summary

Lands the AF_XDP datapath layer that was deferred from #29 (pure-Rust stacks) because it requires `xsk-rs` / `libbpf-sys` which only compile on Linux.  Closes #28.

### What's in this PR

- **Re-add `xdp` cargo feature** on `ironsbe-transport` bringing in `xsk-rs 0.6` as a target-conditional Linux-only dependency.  The `xdp` feature extends `xdp-stacks` so both the pure-Rust stacks (UdpStack, SmoltcpStack) and the xsk-rs datapath are available together.
- **`xdp::datapath` module** (~230 lines): wraps `xsk-rs` UMEM, rx/tx/fill/completion ring queues, and a `poll_once` loop that in a single call reclaims completed tx descriptors, pulls inbound frames (calling `XdpStack::on_rx` per frame), flushes stack timers, and submits outbound frames.  All `unsafe` blocks documented with `// SAFETY:` comments.
- **Feature forwarding** from `ironsbe-server`, `ironsbe-client` and the `ironsbe` umbrella crate so `LocalServer` can be used with XDP backends out of the box.
- **Operational checklist** in `docs/transport-backends.md`: kernel ≥ 5.11, capabilities (`CAP_NET_ADMIN`, `CAP_BPF`), build deps (`libelf-dev`, `zlib1g-dev`, `libpcap-dev`, `clang`, `m4`), NIC driver matrix, `ethtool -N` queue steering recipe, copy vs zero-copy notes.

### Dev loop

This PR was developed using SSH to a real Linux machine (kernel 6.8.0, `igc` NIC driver) for the `xsk-rs`/`libbpf-sys` compilation loop:

```
write locally on macOS → git push → ssh linux 'git pull && cargo clippy --features xdp'
```

Validated clean on both macOS (`--all-features` gates the datapath out) and Linux native (`--features xdp` compiles the full xsk-rs chain).

### Server integration

No new server type needed — the `LocalServer` / `LocalClient` types landed in #30 work for any `LocalTransport` backend, including a future XDP-based one.  The `xdp` feature is forwarded through all workspace crates so `--features xdp` activates the whole chain.

## Test plan

- [x] `cargo check --all-features` on macOS (datapath gated out by target_os)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` on macOS
- [x] `make pre-push` on macOS
- [x] `cargo check -p ironsbe-transport --no-default-features --features xdp` on Linux (native, via SSH)
- [x] `cargo clippy -p ironsbe-transport --no-default-features --features xdp -- -D warnings` on Linux (native, via SSH)
- [ ] CI Linux runners verify the full build chain

### Out of scope

- Runtime integration tests (require `CAP_NET_ADMIN` + a real NIC bound to AF_XDP — CI doesn't have this). The datapath module compiles and the ring logic is structurally correct based on the xsk-rs API exploration, but end-to-end validation needs hardware.
- Benchmark numbers (same reason — need the user to run on their Linux machine).
- Buffer pooling, registered fds, `IORING_OP_SEND_ZC`, zero-copy mode toggle.
- Multi-queue sharding across cores.