### PR TITLE
M2 #16: XdpTransport LocalTransport impl + examples + integration test

### DIFF
--- a/ironsbe-transport/src/xdp/datapath.rs
+++ b/ironsbe-transport/src/xdp/datapath.rs
@@ -159,11 +159,16 @@ impl Datapath {
     /// 4. Submits any frames the stack produced into the tx queue.
     /// 5. Re-fills the fill queue with reclaimed descriptors.
     ///
-    /// Returns the number of inbound frames processed.
+    /// Returns a tuple of `(frames_processed, new_connections)`.  The
+    /// caller should drain the connections vector to hand them to the
+    /// application (e.g. via `LocalListener::accept`).
     ///
     /// # Errors
     /// Returns an `io::Error` if any ring operation fails.
-    pub fn poll_once<S: XdpStack>(&mut self, stack: &mut S) -> io::Result<usize>
+    pub fn poll_once<S: XdpStack>(
+        &mut self,
+        stack: &mut S,
+    ) -> io::Result<(usize, Vec<S::Connection>)>
     where
         S::Error: std::fmt::Display,
     {
@@ -182,6 +187,7 @@ impl Datapath {
         let n_rx = unsafe { self.rx_q.consume(&mut self.rx_scratch) };
         let mut tx_buf: Vec<Vec<u8>> = Vec::new();
         let mut processed = 0usize;
+        let mut new_conns: Vec<S::Connection> = Vec::new();
 
         for i in 0..n_rx {
             let desc = &self.rx_scratch[i];
@@ -192,9 +198,12 @@ impl Datapath {
             let frame_bytes = data.contents();
 
             let mut q = FrameTxQueue::new(&mut tx_buf);
-            stack
+            if let Some(conn) = stack
                 .on_rx(frame_bytes, &mut q)
-                .map_err(|e| io::Error::other(e.to_string()))?;
+                .map_err(|e| io::Error::other(e.to_string()))?
+            {
+                new_conns.push(conn);
+            }
             processed += 1;
         }
 
@@ -251,6 +260,6 @@ impl Datapath {
             self.tx_q.wakeup()?;
         }
 
-        Ok(processed)
+        Ok((processed, new_conns))
     }
 }

--- a/ironsbe-transport/src/xdp/mod.rs
+++ b/ironsbe-transport/src/xdp/mod.rs
@@ -22,8 +22,16 @@ pub mod stack;
 #[cfg(all(feature = "xdp", target_os = "linux"))]
 pub mod datapath;
 
+#[cfg(all(feature = "xdp", target_os = "linux"))]
+pub mod transport;
+
 pub use frames::{
     FrameError, MacAddr, ParsedArp, ParsedFrame, ParsedUdp, build_arp_reply, build_udp_ipv4,
     parse_arp, parse_ethernet, parse_ipv4_udp,
 };
 pub use stack::{FrameTxQueue, SmoltcpStack, UdpStack, XdpStack};
+
+#[cfg(all(feature = "xdp", target_os = "linux"))]
+pub use datapath::{Datapath, DatapathConfig};
+#[cfg(all(feature = "xdp", target_os = "linux"))]
+pub use transport::{XdpConfig, XdpListener, XdpTransport};

--- a/ironsbe-transport/src/xdp/stack/tcp.rs
+++ b/ironsbe-transport/src/xdp/stack/tcp.rs
@@ -359,6 +359,11 @@ impl SmoltcpStackInner {
 }
 
 /// `smoltcp`-based TCP stack.  Single-threaded; not `Send`.
+///
+/// `Clone` produces a shared handle (via `Rc` clone) to the same
+/// internal state, mirroring [`super::udp::UdpStack`].  This is only
+/// used to satisfy the `Clone` bound on `LocalTransport::BindConfig`.
+#[derive(Clone)]
 pub struct SmoltcpStack {
     inner: Rc<RefCell<SmoltcpStackInner>>,
 }

--- a/ironsbe-transport/src/xdp/stack/udp.rs
+++ b/ironsbe-transport/src/xdp/stack/udp.rs
@@ -150,6 +150,12 @@ impl UdpStackInner {
 }
 
 /// UDP-based stack.  Single-threaded; not `Send`.
+///
+/// `Clone` produces a shared handle (via `Rc` clone) to the same
+/// internal state.  This is only used to satisfy the `Clone` bound on
+/// `LocalTransport::BindConfig` at the type level; the stack is never
+/// actually cloned at runtime.
+#[derive(Clone)]
 pub struct UdpStack {
     inner: Rc<RefCell<UdpStackInner>>,
 }

--- a/ironsbe-transport/src/xdp/transport.rs
+++ b/ironsbe-transport/src/xdp/transport.rs
@@ -22,7 +22,7 @@
 
 use super::datapath::{Datapath, DatapathConfig};
 use super::stack::{FrameTxQueue, XdpStack};
-use crate::traits::{LocalConnection, LocalListener, LocalTransport};
+use crate::traits::{LocalListener, LocalTransport};
 use std::io;
 use std::marker::PhantomData;
 use std::net::{IpAddr, SocketAddr};
@@ -69,9 +69,11 @@ impl From<SocketAddr> for XdpConfig<super::stack::UdpStack> {
             IpAddr::V6(_) => std::net::Ipv4Addr::LOCALHOST,
         };
         let mac = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01]; // locally-administered
-        let stack = super::stack::UdpStack::new(
-            super::stack::udp::UdpStackConfig::new(ip, addr.port(), mac),
-        );
+        let stack = super::stack::UdpStack::new(super::stack::udp::UdpStackConfig::new(
+            ip,
+            addr.port(),
+            mac,
+        ));
         Self {
             datapath: DatapathConfig::new("lo", 0),
             stack,
@@ -171,9 +173,11 @@ where
             // This is a temporary simplification; a future refactor
             // will thread the connection out of poll_once directly.
             let mut q = FrameTxQueue::new(&mut tx_buf);
-            if let Some(conn) = self.stack.on_rx(&[], &mut q).map_err(|e| {
-                io::Error::other(format!("stack on_rx: {e}"))
-            })? {
+            if let Some(conn) = self
+                .stack
+                .on_rx(&[], &mut q)
+                .map_err(|e| io::Error::other(format!("stack on_rx: {e}")))?
+            {
                 return Ok(conn);
             }
         }

--- a/ironsbe-transport/src/xdp/transport.rs
+++ b/ironsbe-transport/src/xdp/transport.rs
@@ -21,7 +21,7 @@
 //! [`io::ErrorKind::Unsupported`].
 
 use super::datapath::{Datapath, DatapathConfig};
-use super::stack::{FrameTxQueue, XdpStack};
+use super::stack::XdpStack;
 use crate::traits::{LocalListener, LocalTransport};
 use std::io;
 use std::marker::PhantomData;

--- a/ironsbe-transport/src/xdp/transport.rs
+++ b/ironsbe-transport/src/xdp/transport.rs
@@ -1,0 +1,185 @@
+//! High-level [`LocalTransport`] implementation for the AF_XDP backend.
+//!
+//! `XdpTransport<S>` ties together the [`Datapath`](super::datapath::Datapath)
+//! (xsk-rs UMEM + ring queues) and a user-selected [`XdpStack`] (UDP or
+//! smoltcp TCP) into a single type that satisfies the
+//! [`LocalTransport`] trait so it can be driven by
+//! [`LocalServer`](ironsbe_server::LocalServer).
+//!
+//! # Threading model
+//!
+//! AF_XDP is thread-per-core by design: the datapath is bound to a single
+//! `(interface, queue)` pair, and `poll_once` is not `Send`.  All
+//! operations — bind, accept, recv, send — must happen on the same
+//! thread.  `XdpListener::accept` busy-polls the datapath, which is the
+//! expected behaviour in a kernel-bypass tight loop.
+//!
+//! # Client side
+//!
+//! AF_XDP does not have a "client connect" semantic in the kernel-bypass
+//! model.  `connect_with` always returns
+//! [`io::ErrorKind::Unsupported`].
+
+use super::datapath::{Datapath, DatapathConfig};
+use super::stack::{FrameTxQueue, XdpStack};
+use crate::traits::{LocalConnection, LocalListener, LocalTransport};
+use std::io;
+use std::marker::PhantomData;
+use std::net::{IpAddr, SocketAddr};
+
+/// AF_XDP transport configuration.
+///
+/// Carries the [`DatapathConfig`] (interface name, queue id, UMEM
+/// settings) and a ready-to-use [`XdpStack`] instance that will drive
+/// the L3/L4 layer above the raw frames.
+#[derive(Debug, Clone)]
+pub struct XdpConfig<S> {
+    /// Datapath (xsk-rs) settings.
+    pub datapath: DatapathConfig,
+    /// The userspace network stack that handles L3/L4 above the raw
+    /// Ethernet frames delivered by AF_XDP.
+    pub stack: S,
+    /// TCP/UDP port the stack listens on (used for `local_addr()`
+    /// reporting only — the actual binding is done by the stack).
+    pub listen_port: u16,
+}
+
+impl<S: XdpStack + Clone> XdpConfig<S> {
+    /// Creates a new XDP config.
+    #[must_use]
+    pub fn new(datapath: DatapathConfig, stack: S, listen_port: u16) -> Self {
+        Self {
+            datapath,
+            stack,
+            listen_port,
+        }
+    }
+}
+
+/// Fallback `From<SocketAddr>` required by the `LocalTransport` trait.
+///
+/// Builds a default config on `lo` queue 0 — useful for tests and
+/// examples but unlikely to be the right choice for production, where
+/// the caller should construct an explicit [`XdpConfig`] with the
+/// correct interface and stack.
+impl From<SocketAddr> for XdpConfig<super::stack::UdpStack> {
+    fn from(addr: SocketAddr) -> Self {
+        let ip = match addr.ip() {
+            IpAddr::V4(v4) => v4,
+            IpAddr::V6(_) => std::net::Ipv4Addr::LOCALHOST,
+        };
+        let mac = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01]; // locally-administered
+        let stack = super::stack::UdpStack::new(
+            super::stack::udp::UdpStackConfig::new(ip, addr.port(), mac),
+        );
+        Self {
+            datapath: DatapathConfig::new("lo", 0),
+            stack,
+            listen_port: addr.port(),
+        }
+    }
+}
+
+/// AF_XDP transport backend.
+///
+/// Generic over the userspace stack `S`.  Use
+/// [`super::stack::UdpStack`] for lowest-latency UDP framing or
+/// [`super::stack::SmoltcpStack`] for wire-compatible TCP.
+pub struct XdpTransport<S: XdpStack>(PhantomData<S>);
+
+impl<S> LocalTransport for XdpTransport<S>
+where
+    S: XdpStack + Clone + 'static,
+    S::Connection: 'static,
+    S::Error: std::fmt::Display + 'static,
+    XdpConfig<S>: From<SocketAddr> + Clone + 'static,
+{
+    type Listener = XdpListener<S>;
+    type Connection = S::Connection;
+    type Error = io::Error;
+    type BindConfig = XdpConfig<S>;
+    type ConnectConfig = XdpConfig<S>;
+
+    async fn bind_with(config: XdpConfig<S>) -> io::Result<XdpListener<S>> {
+        let datapath = Datapath::bind(&config.datapath)?;
+        let local_ip = config.stack.local_ip();
+        let listen_port = config.listen_port;
+        Ok(XdpListener {
+            datapath,
+            stack: config.stack,
+            local_addr: SocketAddr::new(local_ip, listen_port),
+        })
+    }
+
+    async fn connect_with(_config: XdpConfig<S>) -> io::Result<S::Connection> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "AF_XDP does not support client-side connect; \
+             use a regular TCP/UDP client to talk to an XDP server",
+        ))
+    }
+}
+
+/// AF_XDP listener that busy-polls the datapath until the stack yields
+/// a new connection.
+pub struct XdpListener<S: XdpStack> {
+    datapath: Datapath,
+    stack: S,
+    local_addr: SocketAddr,
+}
+
+impl<S> LocalListener for XdpListener<S>
+where
+    S: XdpStack + 'static,
+    S::Connection: 'static,
+    S::Error: std::fmt::Display + 'static,
+{
+    type Connection = S::Connection;
+    type Error = io::Error;
+
+    async fn accept(&mut self) -> io::Result<S::Connection> {
+        // Busy-poll the datapath + stack until a new connection is
+        // yielded.  This is the expected pattern for a kernel-bypass
+        // tight loop.  In a cooperative runtime the caller should
+        // wrap this in a dedicated thread or use `spawn_blocking`.
+        loop {
+            let mut tx_buf: Vec<Vec<u8>> = Vec::new();
+
+            // Drive one round of rx → stack → tx.
+            self.datapath.poll_once(&mut self.stack)?;
+
+            // Drain any outbound frames the stack produced (ARP
+            // replies, TCP SYN-ACK, …).  The datapath's poll_once
+            // already submitted them to the tx ring internally via
+            // the FrameTxQueue plumbing, so there is nothing extra
+            // to do here — the frames were already handed to the
+            // kernel.
+
+            // Check if the stack accepted a new connection.
+            // For UdpStack this happens on the first packet from a
+            // new peer; for SmoltcpStack this happens when a TCP
+            // handshake completes.
+            //
+            // We re-poll immediately rather than yielding because
+            // busy-polling is the whole point of AF_XDP.
+            //
+            // TODO: the XdpStack::on_rx already returns
+            // Option<Connection> from inside poll_once but we don't
+            // surface it here yet.  For now we rely on the stack's
+            // internal accept queue and drain it below.
+            //
+            // This is a temporary simplification; a future refactor
+            // will thread the connection out of poll_once directly.
+            let mut q = FrameTxQueue::new(&mut tx_buf);
+            if let Some(conn) = self.stack.on_rx(&[], &mut q).map_err(|e| {
+                io::Error::other(format!("stack on_rx: {e}"))
+            })? {
+                return Ok(conn);
+            }
+        }
+    }
+
+    fn local_addr(&self) -> io::Result<SocketAddr> {
+        Ok(self.local_addr)
+    }
+}

--- a/ironsbe-transport/src/xdp/transport.rs
+++ b/ironsbe-transport/src/xdp/transport.rs
@@ -110,6 +110,7 @@ where
             datapath,
             stack: config.stack,
             local_addr: SocketAddr::new(local_ip, listen_port),
+            pending_conns: std::collections::VecDeque::new(),
         })
     }
 
@@ -128,6 +129,9 @@ pub struct XdpListener<S: XdpStack> {
     datapath: Datapath,
     stack: S,
     local_addr: SocketAddr,
+    /// Buffer for connections that were accepted during a single
+    /// `poll_once` round but not yet returned by `accept`.
+    pending_conns: std::collections::VecDeque<S::Connection>,
 }
 
 impl<S> LocalListener for XdpListener<S>
@@ -140,45 +144,33 @@ where
     type Error = io::Error;
 
     async fn accept(&mut self) -> io::Result<S::Connection> {
-        // Busy-poll the datapath + stack until a new connection is
-        // yielded.  This is the expected pattern for a kernel-bypass
-        // tight loop.  In a cooperative runtime the caller should
-        // wrap this in a dedicated thread or use `spawn_blocking`.
         loop {
-            let mut tx_buf: Vec<Vec<u8>> = Vec::new();
-
-            // Drive one round of rx → stack → tx.
-            self.datapath.poll_once(&mut self.stack)?;
-
-            // Drain any outbound frames the stack produced (ARP
-            // replies, TCP SYN-ACK, …).  The datapath's poll_once
-            // already submitted them to the tx ring internally via
-            // the FrameTxQueue plumbing, so there is nothing extra
-            // to do here — the frames were already handed to the
-            // kernel.
-
-            // Check if the stack accepted a new connection.
-            // For UdpStack this happens on the first packet from a
-            // new peer; for SmoltcpStack this happens when a TCP
-            // handshake completes.
-            //
-            // We re-poll immediately rather than yielding because
-            // busy-polling is the whole point of AF_XDP.
-            //
-            // TODO: the XdpStack::on_rx already returns
-            // Option<Connection> from inside poll_once but we don't
-            // surface it here yet.  For now we rely on the stack's
-            // internal accept queue and drain it below.
-            //
-            // This is a temporary simplification; a future refactor
-            // will thread the connection out of poll_once directly.
-            let mut q = FrameTxQueue::new(&mut tx_buf);
-            if let Some(conn) = self
-                .stack
-                .on_rx(&[], &mut q)
-                .map_err(|e| io::Error::other(format!("stack on_rx: {e}")))?
-            {
+            // 1. Drain any connections buffered from a previous
+            //    poll_once round.
+            if let Some(conn) = self.pending_conns.pop_front() {
                 return Ok(conn);
+            }
+
+            // 2. Drive one round of rx → stack → tx.  poll_once now
+            //    surfaces any connections that on_rx produced.
+            let (n_rx, new_conns) = self.datapath.poll_once(&mut self.stack)?;
+
+            for conn in new_conns {
+                self.pending_conns.push_back(conn);
+            }
+
+            // If we got a connection this round, return it
+            // immediately.
+            if let Some(conn) = self.pending_conns.pop_front() {
+                return Ok(conn);
+            }
+
+            // 3. If no frames were processed, yield to the executor
+            //    so session tasks and timers can make progress.
+            //    When frames ARE flowing we stay in the busy loop
+            //    (the whole point of AF_XDP).
+            if n_rx == 0 {
+                tokio::task::yield_now().await;
             }
         }
     }

--- a/ironsbe-transport/tests/xdp_end_to_end.rs
+++ b/ironsbe-transport/tests/xdp_end_to_end.rs
@@ -23,7 +23,7 @@
 use ironsbe_transport::traits::{LocalListener, LocalTransport};
 use ironsbe_transport::xdp::stack::udp::UdpStackConfig;
 use ironsbe_transport::xdp::{DatapathConfig, UdpStack, XdpConfig, XdpTransport};
-use std::net::{Ipv4Addr, SocketAddr, UdpSocket};
+use std::net::{Ipv4Addr, UdpSocket};
 
 const LOCAL_MAC: [u8; 6] = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
 const LOCAL_IP: Ipv4Addr = Ipv4Addr::new(127, 0, 0, 1);

--- a/ironsbe-transport/tests/xdp_end_to_end.rs
+++ b/ironsbe-transport/tests/xdp_end_to_end.rs
@@ -20,11 +20,9 @@
 
 #![cfg(all(feature = "xdp", target_os = "linux"))]
 
-use ironsbe_transport::xdp::{
-    DatapathConfig, UdpStack, XdpConfig, XdpTransport,
-};
-use ironsbe_transport::xdp::stack::udp::UdpStackConfig;
 use ironsbe_transport::traits::{LocalListener, LocalTransport};
+use ironsbe_transport::xdp::stack::udp::UdpStackConfig;
+use ironsbe_transport::xdp::{DatapathConfig, UdpStack, XdpConfig, XdpTransport};
 use std::net::{Ipv4Addr, SocketAddr, UdpSocket};
 
 const LOCAL_MAC: [u8; 6] = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
@@ -61,13 +59,10 @@ fn test_xdp_udp_stack_receives_frame_from_regular_socket() {
             .expect("send");
 
         // Accept the connection produced by UdpStack::on_rx.
-        let conn = tokio::time::timeout(
-            std::time::Duration::from_secs(5),
-            listener.accept(),
-        )
-        .await
-        .expect("accept timeout")
-        .expect("accept error");
+        let conn = tokio::time::timeout(std::time::Duration::from_secs(5), listener.accept())
+            .await
+            .expect("accept timeout")
+            .expect("accept error");
 
         // The first recv should yield the payload we sent.
         use ironsbe_transport::traits::LocalConnection;

--- a/ironsbe-transport/tests/xdp_end_to_end.rs
+++ b/ironsbe-transport/tests/xdp_end_to_end.rs
@@ -1,0 +1,82 @@
+//! End-to-end AF_XDP integration test.
+//!
+//! This test is `#[ignore]` by default because it requires:
+//!
+//! - Linux kernel ≥ 5.11
+//! - `CAP_NET_ADMIN` + `CAP_BPF` (or root)
+//! - A NIC / veth with XDP support
+//! - Build deps for `libbpf-sys` (`libelf-dev`, `clang`, etc.)
+//!
+//! To run manually:
+//!
+//! ```sh
+//! sudo -E cargo test -p ironsbe-transport --test xdp_end_to_end \
+//!     --features xdp -- --ignored --nocapture
+//! ```
+//!
+//! The test binds an AF_XDP socket on `lo` queue 0 in copy mode and
+//! validates that the `UdpStack` can receive a length-prefixed frame
+//! sent from a regular UDP socket.
+
+#![cfg(all(feature = "xdp", target_os = "linux"))]
+
+use ironsbe_transport::xdp::{
+    DatapathConfig, UdpStack, XdpConfig, XdpTransport,
+};
+use ironsbe_transport::xdp::stack::udp::UdpStackConfig;
+use ironsbe_transport::traits::{LocalListener, LocalTransport};
+use std::net::{Ipv4Addr, SocketAddr, UdpSocket};
+
+const LOCAL_MAC: [u8; 6] = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
+const LOCAL_IP: Ipv4Addr = Ipv4Addr::new(127, 0, 0, 1);
+const LOCAL_PORT: u16 = 19000;
+const PAYLOAD: &[u8] = b"hello-xdp";
+
+#[test]
+#[ignore = "requires CAP_NET_ADMIN + AF_XDP-capable interface (run with sudo)"]
+fn test_xdp_udp_stack_receives_frame_from_regular_socket() {
+    let stack = UdpStack::new(UdpStackConfig::new(LOCAL_IP, LOCAL_PORT, LOCAL_MAC));
+    let datapath_cfg = DatapathConfig::new("lo", 0);
+    let xdp_cfg = XdpConfig::new(datapath_cfg, stack, LOCAL_PORT);
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build runtime");
+    let local = tokio::task::LocalSet::new();
+
+    local.block_on(&rt, async {
+        let mut listener = XdpTransport::<UdpStack>::bind_with(xdp_cfg)
+            .await
+            .expect("bind AF_XDP on lo");
+
+        // Send a length-prefixed datagram from a regular UDP socket.
+        let sender = UdpSocket::bind("127.0.0.1:0").expect("bind sender");
+        let frame_len = PAYLOAD.len() as u32;
+        let mut datagram = Vec::with_capacity(4 + PAYLOAD.len());
+        datagram.extend_from_slice(&frame_len.to_le_bytes());
+        datagram.extend_from_slice(PAYLOAD);
+        sender
+            .send_to(&datagram, format!("127.0.0.1:{LOCAL_PORT}"))
+            .expect("send");
+
+        // Accept the connection produced by UdpStack::on_rx.
+        let conn = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            listener.accept(),
+        )
+        .await
+        .expect("accept timeout")
+        .expect("accept error");
+
+        // The first recv should yield the payload we sent.
+        use ironsbe_transport::traits::LocalConnection;
+        let mut conn = conn;
+        let msg = conn
+            .recv()
+            .await
+            .expect("recv")
+            .expect("frame should be available");
+        assert_eq!(&msg[..], PAYLOAD);
+    });
+}

--- a/ironsbe/Cargo.toml
+++ b/ironsbe/Cargo.toml
@@ -45,6 +45,14 @@ path = "examples/uring_server.rs"
 name = "uring_client"
 path = "examples/uring_client.rs"
 
+[[example]]
+name = "xdp_server"
+path = "examples/xdp_server.rs"
+
+[[example]]
+name = "xdp_client"
+path = "examples/xdp_client.rs"
+
 [features]
 default = []
 # Linux-only io_uring backend.  Forwards to the matching feature in

--- a/ironsbe/examples/xdp_client.rs
+++ b/ironsbe/examples/xdp_client.rs
@@ -1,0 +1,49 @@
+//! Example client that talks to an XDP server via a regular UDP socket.
+//!
+//! AF_XDP does not have a "client connect" concept — the kernel-bypass
+//! path is for the **server** side only.  Clients just use a normal
+//! UDP (or TCP, if the server runs SmoltcpStack) socket.
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo run -p ironsbe --example xdp_client
+//! ```
+//!
+//! Make sure the `xdp_server` example is running first.
+
+use std::net::UdpSocket;
+use std::time::Duration;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let server_addr = "10.0.0.1:9000";
+    println!("[xdp client] Sending to {server_addr} via regular UDP");
+
+    let sock = UdpSocket::bind("0.0.0.0:0")?;
+    sock.set_read_timeout(Some(Duration::from_secs(2)))?;
+
+    for i in 0..5u32 {
+        // Build a length-prefixed SBE message (matches UdpStack's wire
+        // format: 4-byte LE length + payload).
+        let payload = format!("hello-{i}");
+        let frame_len = payload.len() as u32;
+        let mut datagram = Vec::with_capacity(4 + payload.len());
+        datagram.extend_from_slice(&frame_len.to_le_bytes());
+        datagram.extend_from_slice(payload.as_bytes());
+
+        sock.send_to(&datagram, server_addr)?;
+        println!("[xdp client] sent: {payload}");
+
+        let mut buf = [0u8; 2048];
+        match sock.recv_from(&mut buf) {
+            Ok((n, from)) => {
+                println!("[xdp client] echo from {from}: {} bytes", n);
+            }
+            Err(e) => {
+                eprintln!("[xdp client] recv timeout or error: {e}");
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/ironsbe/examples/xdp_client.rs
+++ b/ironsbe/examples/xdp_client.rs
@@ -12,8 +12,20 @@
 //!
 //! Make sure the `xdp_server` example is running first.
 
+use ironsbe_core::buffer::{AlignedBuffer, ReadBuffer, WriteBuffer};
+use ironsbe_core::header::MessageHeader;
 use std::net::UdpSocket;
 use std::time::Duration;
+
+/// Builds a valid SBE-framed message: `MessageHeader` + payload.
+fn create_sbe_message(template_id: u16, payload: &[u8]) -> Vec<u8> {
+    let mut buffer = AlignedBuffer::<256>::new();
+    let header = MessageHeader::new(payload.len() as u16, template_id, 1, 1);
+    header.encode(&mut buffer, 0);
+    let header_size = MessageHeader::ENCODED_LENGTH;
+    buffer.as_mut_slice()[header_size..header_size + payload.len()].copy_from_slice(payload);
+    buffer.as_slice()[..header_size + payload.len()].to_vec()
+}
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let server_addr = "10.0.0.1:9000";
@@ -24,20 +36,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for i in 0..5u32 {
         // Build a length-prefixed SBE message (matches UdpStack's wire
-        // format: 4-byte LE length + payload).
-        let payload = format!("hello-{i}");
-        let frame_len = payload.len() as u32;
-        let mut datagram = Vec::with_capacity(4 + payload.len());
+        // format: 4-byte LE length + SBE message).
+        let sbe_msg = create_sbe_message(1, format!("hello-{i}").as_bytes());
+        let frame_len = sbe_msg.len() as u32;
+        let mut datagram = Vec::with_capacity(4 + sbe_msg.len());
         datagram.extend_from_slice(&frame_len.to_le_bytes());
-        datagram.extend_from_slice(payload.as_bytes());
+        datagram.extend_from_slice(&sbe_msg);
 
         sock.send_to(&datagram, server_addr)?;
-        println!("[xdp client] sent: {payload}");
+        println!("[xdp client] sent message #{i} ({} bytes)", sbe_msg.len());
 
         let mut buf = [0u8; 2048];
         match sock.recv_from(&mut buf) {
             Ok((n, from)) => {
-                println!("[xdp client] echo from {from}: {} bytes", n);
+                println!("[xdp client] echo from {from}: {n} bytes");
             }
             Err(e) => {
                 eprintln!("[xdp client] recv timeout or error: {e}");

--- a/ironsbe/examples/xdp_server.rs
+++ b/ironsbe/examples/xdp_server.rs
@@ -13,10 +13,8 @@
 mod imp {
     use ironsbe_core::header::MessageHeader;
     use ironsbe_server::{LocalServerBuilder, MessageHandler, Responder, ServerError};
-    use ironsbe_transport::xdp::{
-        DatapathConfig, UdpStack, XdpConfig, XdpTransport,
-    };
     use ironsbe_transport::xdp::stack::udp::UdpStackConfig;
+    use ironsbe_transport::xdp::{DatapathConfig, UdpStack, XdpConfig, XdpTransport};
     use std::net::Ipv4Addr;
 
     struct EchoHandler;

--- a/ironsbe/examples/xdp_server.rs
+++ b/ironsbe/examples/xdp_server.rs
@@ -1,0 +1,94 @@
+//! Example IronSBE server running on the AF_XDP backend with UdpStack.
+//!
+//! Run with (requires root / `CAP_NET_ADMIN` + `CAP_BPF`):
+//!
+//! ```sh
+//! sudo cargo run -p ironsbe --example xdp_server --features xdp
+//! ```
+//!
+//! On non-Linux platforms (or without the `xdp` feature) the binary
+//! still compiles but `main` exits early with a clear message.
+
+#[cfg(all(feature = "xdp", target_os = "linux"))]
+mod imp {
+    use ironsbe_core::header::MessageHeader;
+    use ironsbe_server::{LocalServerBuilder, MessageHandler, Responder, ServerError};
+    use ironsbe_transport::xdp::{
+        DatapathConfig, UdpStack, XdpConfig, XdpTransport,
+    };
+    use ironsbe_transport::xdp::stack::udp::UdpStackConfig;
+    use std::net::Ipv4Addr;
+
+    struct EchoHandler;
+
+    impl MessageHandler for EchoHandler {
+        fn on_message(
+            &self,
+            session_id: u64,
+            _header: &MessageHeader,
+            buffer: &[u8],
+            responder: &dyn Responder,
+        ) {
+            if let Err(e) = responder.send(buffer) {
+                eprintln!("[xdp server] session {session_id} echo failed: {e:?}");
+            }
+        }
+
+        fn on_session_start(&self, session_id: u64) {
+            println!("[xdp server] session {session_id} connected");
+        }
+
+        fn on_session_end(&self, session_id: u64) {
+            println!("[xdp server] session {session_id} disconnected");
+        }
+    }
+
+    pub(crate) fn run() -> Result<(), ServerError> {
+        tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .init();
+
+        let local_mac = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
+        let local_ip = Ipv4Addr::new(10, 0, 0, 1);
+        let local_port = 9000u16;
+
+        let stack = UdpStack::new(UdpStackConfig::new(local_ip, local_port, local_mac));
+        let datapath_cfg = DatapathConfig::new("eth0", 0);
+        let xdp_cfg = XdpConfig::new(datapath_cfg, stack, local_port);
+
+        let (mut server, _handle) =
+            LocalServerBuilder::<EchoHandler, XdpTransport<UdpStack>>::new()
+                .bind_config(xdp_cfg)
+                .handler(EchoHandler)
+                .max_connections(64)
+                .build();
+
+        println!("[xdp server] Starting on eth0 queue 0, UDP port {local_port}");
+        println!("[xdp server] Press Ctrl+C to stop");
+        println!("[xdp server] NOTE: requires sudo / CAP_NET_ADMIN + CAP_BPF");
+
+        // AF_XDP is single-threaded; we drive the server in a blocking
+        // loop on the current thread.  tokio_uring or a plain LocalSet
+        // provides the reactor.
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build tokio runtime");
+        let local = tokio::task::LocalSet::new();
+        local.block_on(&rt, async move { server.run().await })?;
+        Ok(())
+    }
+}
+
+#[cfg(all(feature = "xdp", target_os = "linux"))]
+fn main() -> Result<(), ironsbe_server::ServerError> {
+    imp::run()
+}
+
+#[cfg(not(all(feature = "xdp", target_os = "linux")))]
+fn main() {
+    eprintln!(
+        "xdp_server example requires --features xdp on Linux \
+         (kernel >= 5.11).  This build does not have it enabled."
+    );
+}


### PR DESCRIPTION
## Summary

Closes #16 by landing the final piece of the AF_XDP backend: the high-level `XdpTransport<S: XdpStack>` type that implements `LocalTransport`, tying together the xsk-rs datapath (#33) and the pure-Rust stacks (#29) into a usable transport for `LocalServer`.

### What's in this PR

- **`XdpTransport<S: XdpStack>`** implementing `LocalTransport`.
  - `bind_with(XdpConfig)` creates a `Datapath` + stack, returns an `XdpListener`.
  - `XdpListener::accept()` busy-polls the datapath (calling `stack.on_rx` per frame) until the stack yields a new connection.
  - `connect_with` returns `Err(Unsupported)` — AF_XDP is server-side only.
- **`XdpConfig<S>`** carrying `DatapathConfig` + stack instance + listen port.  `From<SocketAddr>` builds a default UdpStack on `lo` queue 0 for tests.
- **`examples/xdp_server.rs`** — `LocalServer` + `XdpTransport<UdpStack>` echo server (requires sudo).
- **`examples/xdp_client.rs`** — regular `UdpSocket` client that talks to the XDP server.
- **`tests/xdp_end_to_end.rs`** — `#[ignore]` integration test that binds AF_XDP on `lo`, sends a frame from a regular UDP socket, and asserts the `UdpStack` receives the payload.

### AF_XDP backend status (full #16 scope)

| Piece | PR | Status |
|---|---|---|
| Frame parsers + XdpStack trait + UdpStack + SmoltcpStack | #29 | Merged |
| xsk-rs datapath + feature forwarding + CI deps + operational docs | #33 | Merged |
| **XdpTransport + examples + integration test** | **this PR** | **New** |
| Bench numbers tcp-tokio vs tcp-uring vs xdp | TBD | User runs on hardware |

## Test plan

- [x] `cargo check --all-features --all-targets` on macOS (xdp transport gated out)
- [x] `cargo clippy -p ironsbe-transport --no-default-features --features xdp -- -D warnings` on Linux (via SSH)
- [x] `make pre-push` on macOS
- [ ] CI Linux runners verify the full build chain
- [ ] `sudo cargo test -p ironsbe-transport --test xdp_end_to_end --features xdp -- --ignored` (manual, hardware)