### PR TITLE
M2 #17: DPDK transport backend crate (AF_XDP PMD mode)

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -38,6 +38,7 @@ jobs:
           cargo tarpaulin
           --all-features
           --workspace
+          --exclude ironsbe-transport-dpdk
           --timeout 180
           --out Xml
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ members = [
     "ironsbe-marketdata",
     "ironsbe-bench",
 ]
+# ironsbe-transport-dpdk is excluded from the default build because it
+# requires libdpdk-dev (Linux-only).  Build it explicitly:
+#   cargo build -p ironsbe-transport-dpdk
+exclude = ["ironsbe-transport-dpdk"]
 
 [workspace.package]
 edition = "2024"
@@ -51,6 +55,7 @@ socket2 = "0.5"
 tokio-uring = "0.5"
 smoltcp = { version = "0.12", default-features = false, features = ["std", "medium-ethernet", "proto-ipv4", "socket-tcp"] }
 xsk-rs = "0.6"
+pkg-config = "0.3"
 etherparse = "0.18"
 futures = "0.3"
 async-trait = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,25 @@ members = [
     "ironsbe-client",
     "ironsbe-marketdata",
     "ironsbe-bench",
+    # ironsbe-transport-dpdk requires libdpdk-dev (Linux-only, DPDK 23.11+).
+    # It is in the workspace for dep resolution but NOT in default-members
+    # so `cargo build` / `cargo test` skip it unless you opt in:
+    #   cargo build -p ironsbe-transport-dpdk
+    "ironsbe-transport-dpdk",
 ]
-# ironsbe-transport-dpdk is excluded from the default build because it
-# requires libdpdk-dev (Linux-only).  Build it explicitly:
-#   cargo build -p ironsbe-transport-dpdk
-exclude = ["ironsbe-transport-dpdk"]
+default-members = [
+    "ironsbe",
+    "ironsbe-core",
+    "ironsbe-schema",
+    "ironsbe-codegen",
+    "ironsbe-derive",
+    "ironsbe-channel",
+    "ironsbe-transport",
+    "ironsbe-server",
+    "ironsbe-client",
+    "ironsbe-marketdata",
+    "ironsbe-bench",
+]
 
 [workspace.package]
 edition = "2024"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,6 @@ socket2 = "0.5"
 tokio-uring = "0.5"
 smoltcp = { version = "0.12", default-features = false, features = ["std", "medium-ethernet", "proto-ipv4", "socket-tcp"] }
 xsk-rs = "0.6"
-pkg-config = "0.3"
 etherparse = "0.18"
 futures = "0.3"
 async-trait = "0.1"

--- a/ironsbe-transport-dpdk/Cargo.toml
+++ b/ironsbe-transport-dpdk/Cargo.toml
@@ -21,6 +21,7 @@ ironsbe-transport = { workspace = true, features = ["xdp-stacks"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 bytes = { workspace = true }
+tokio = { workspace = true }
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/ironsbe-transport-dpdk/Cargo.toml
+++ b/ironsbe-transport-dpdk/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "ironsbe-transport-dpdk"
+description = "DPDK transport backend for IronSBE (Linux-only, opt-in)"
+version = "0.3.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords = ["dpdk", "transport", "low-latency", "kernel-bypass"]
+categories = ["network-programming"]
+
+# This crate is NOT in the default workspace members.  It requires
+# libdpdk-dev (DPDK 23.11+) installed on the build machine.  Add it
+# explicitly:
+#
+#   cargo build -p ironsbe-transport-dpdk
+
+[dependencies]
+ironsbe-transport = { workspace = true, features = ["xdp-stacks"] }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+bytes = { workspace = true }
+
+[build-dependencies]
+pkg-config = "0.3"

--- a/ironsbe-transport-dpdk/build.rs
+++ b/ironsbe-transport-dpdk/build.rs
@@ -1,28 +1,19 @@
 //! Build script that probes for `libdpdk` via `pkg-config`.
 //!
-//! If DPDK is not installed, the build fails with a clear message
-//! pointing the user at the install instructions.
+//! `pkg-config` emits the correct `cargo:rustc-link-lib` and
+//! `cargo:rustc-link-search` metadata automatically, so no manual
+//! flag loops are needed.
 
 fn main() {
-    match pkg_config::Config::new()
+    if let Err(e) = pkg_config::Config::new()
         .atleast_version("23.11")
         .probe("libdpdk")
     {
-        Ok(lib) => {
-            for path in &lib.link_paths {
-                println!("cargo:rustc-link-search=native={}", path.display());
-            }
-            for lib_name in &lib.libs {
-                println!("cargo:rustc-link-lib={lib_name}");
-            }
-        }
-        Err(e) => {
-            panic!(
-                "\n\nironsbe-transport-dpdk requires DPDK >= 23.11.\n\
-                 Install it with:\n\n\
-                 \tsudo apt-get install -y libdpdk-dev\n\n\
-                 pkg-config error: {e}\n"
-            );
-        }
+        panic!(
+            "\n\nironsbe-transport-dpdk requires DPDK >= 23.11.\n\
+             Install it with:\n\n\
+             \tsudo apt-get install -y libdpdk-dev\n\n\
+             pkg-config error: {e}\n"
+        );
     }
 }

--- a/ironsbe-transport-dpdk/build.rs
+++ b/ironsbe-transport-dpdk/build.rs
@@ -1,0 +1,28 @@
+//! Build script that probes for `libdpdk` via `pkg-config`.
+//!
+//! If DPDK is not installed, the build fails with a clear message
+//! pointing the user at the install instructions.
+
+fn main() {
+    match pkg_config::Config::new()
+        .atleast_version("23.11")
+        .probe("libdpdk")
+    {
+        Ok(lib) => {
+            for path in &lib.link_paths {
+                println!("cargo:rustc-link-search=native={}", path.display());
+            }
+            for lib_name in &lib.libs {
+                println!("cargo:rustc-link-lib={lib_name}");
+            }
+        }
+        Err(e) => {
+            panic!(
+                "\n\nironsbe-transport-dpdk requires DPDK >= 23.11.\n\
+                 Install it with:\n\n\
+                 \tsudo apt-get install -y libdpdk-dev\n\n\
+                 pkg-config error: {e}\n"
+            );
+        }
+    }
+}

--- a/ironsbe-transport-dpdk/src/eal.rs
+++ b/ironsbe-transport-dpdk/src/eal.rs
@@ -1,0 +1,68 @@
+//! DPDK EAL (Environment Abstraction Layer) initialization and cleanup.
+//!
+//! The EAL must be initialized exactly once per process before any
+//! DPDK function can be called.  [`Eal::init`] wraps
+//! `rte_eal_init` and [`Eal`]'s `Drop` calls `rte_eal_cleanup`.
+
+use crate::ffi;
+use std::ffi::{CString, NulError};
+use std::io;
+
+/// RAII guard for the DPDK EAL.
+///
+/// Created by [`Eal::init`].  When dropped, calls `rte_eal_cleanup`
+/// to release EAL resources.  Only one instance may exist per process.
+pub struct Eal {
+    /// Owned CStrings backing the argv pointers so they live as long
+    /// as EAL might reference them (DPDK stores pointers internally).
+    _args: Vec<CString>,
+}
+
+impl Eal {
+    /// Initializes the DPDK EAL with the given command-line arguments.
+    ///
+    /// For testing with the AF_XDP PMD on loopback without hugepages:
+    ///
+    /// ```text
+    /// ["ironsbe", "--no-huge", "--proc-type=primary",
+    ///  "--vdev=net_af_xdp0,iface=eth0,start_queue=0,queue_count=1"]
+    /// ```
+    ///
+    /// # Errors
+    /// Returns an `io::Error` if EAL initialization fails (missing
+    /// capabilities, invalid args, …).
+    pub fn init(args: &[&str]) -> io::Result<Self> {
+        let c_args: Vec<CString> = args
+            .iter()
+            .map(|s| CString::new(*s))
+            .collect::<Result<Vec<_>, NulError>>()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+
+        let mut ptrs: Vec<*mut i8> = c_args.iter().map(|s| s.as_ptr() as *mut i8).collect();
+
+        // SAFETY: we pass valid C strings whose lifetimes outlive
+        // this call (stored in `_args` on success).  EAL init is
+        // required to be called exactly once per process.
+        let ret = unsafe { ffi::rte_eal_init(ptrs.len() as i32, ptrs.as_mut_ptr()) };
+
+        if ret < 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("rte_eal_init failed with code {ret}"),
+            ));
+        }
+
+        tracing::info!(parsed_args = ret, "DPDK EAL initialized");
+        Ok(Self { _args: c_args })
+    }
+}
+
+impl Drop for Eal {
+    fn drop(&mut self) {
+        // SAFETY: EAL was successfully initialized in `init`.
+        unsafe {
+            ffi::rte_eal_cleanup();
+        }
+        tracing::info!("DPDK EAL cleaned up");
+    }
+}

--- a/ironsbe-transport-dpdk/src/eal.rs
+++ b/ironsbe-transport-dpdk/src/eal.rs
@@ -46,10 +46,9 @@ impl Eal {
         let ret = unsafe { ffi::rte_eal_init(ptrs.len() as i32, ptrs.as_mut_ptr()) };
 
         if ret < 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                format!("rte_eal_init failed with code {ret}"),
-            ));
+            return Err(io::Error::other(format!(
+                "rte_eal_init failed with code {ret}"
+            )));
         }
 
         tracing::info!(parsed_args = ret, "DPDK EAL initialized");

--- a/ironsbe-transport-dpdk/src/eal.rs
+++ b/ironsbe-transport-dpdk/src/eal.rs
@@ -7,19 +7,47 @@
 use crate::ffi;
 use std::ffi::{CString, NulError};
 use std::io;
+use std::sync::{Arc, OnceLock};
 
-/// RAII guard for the DPDK EAL.
-///
-/// Created by [`Eal::init`].  When dropped, calls `rte_eal_cleanup`
-/// to release EAL resources.  Only one instance may exist per process.
-pub struct Eal {
+/// Global EAL state — ensures `rte_eal_init` is called exactly once
+/// per process, and `rte_eal_cleanup` only runs when the last
+/// [`Eal`] handle is dropped.
+static EAL_INNER: OnceLock<Arc<EalInner>> = OnceLock::new();
+
+struct EalInner {
     /// Owned CStrings backing the argv pointers so they live as long
     /// as EAL might reference them (DPDK stores pointers internally).
     _args: Vec<CString>,
 }
 
+impl Drop for EalInner {
+    fn drop(&mut self) {
+        // SAFETY: EAL was successfully initialized.
+        unsafe {
+            ffi::rte_eal_cleanup();
+        }
+        tracing::info!("DPDK EAL cleaned up");
+    }
+}
+
+/// RAII guard for the DPDK EAL.
+///
+/// Created by [`Eal::init`].  Multiple handles can exist (via
+/// `Clone`); `rte_eal_cleanup` is called only when the **last**
+/// handle is dropped.  The first call to [`init`](Self::init)
+/// performs `rte_eal_init`; subsequent calls return a shared handle
+/// to the already-initialized EAL.
+#[derive(Clone)]
+pub struct Eal {
+    _inner: Arc<EalInner>,
+}
+
 impl Eal {
     /// Initializes the DPDK EAL with the given command-line arguments.
+    ///
+    /// If EAL has already been initialized in this process, subsequent
+    /// calls return a shared handle without calling `rte_eal_init`
+    /// again (DPDK's "init exactly once" rule).
     ///
     /// For testing with the AF_XDP PMD on loopback without hugepages:
     ///
@@ -29,9 +57,16 @@ impl Eal {
     /// ```
     ///
     /// # Errors
-    /// Returns an `io::Error` if EAL initialization fails (missing
-    /// capabilities, invalid args, …).
+    /// Returns an `io::Error` if the first EAL initialization fails
+    /// (missing capabilities, invalid args, …).
     pub fn init(args: &[&str]) -> io::Result<Self> {
+        // If already initialized, return a shared handle.
+        if let Some(inner) = EAL_INNER.get() {
+            return Ok(Self {
+                _inner: Arc::clone(inner),
+            });
+        }
+
         let c_args: Vec<CString> = args
             .iter()
             .map(|s| CString::new(*s))
@@ -41,8 +76,8 @@ impl Eal {
         let mut ptrs: Vec<*mut i8> = c_args.iter().map(|s| s.as_ptr() as *mut i8).collect();
 
         // SAFETY: we pass valid C strings whose lifetimes outlive
-        // this call (stored in `_args` on success).  EAL init is
-        // required to be called exactly once per process.
+        // this call (stored in `_args` on success).  OnceLock
+        // guarantees this runs at most once.
         let ret = unsafe { ffi::rte_eal_init(ptrs.len() as i32, ptrs.as_mut_ptr()) };
 
         if ret < 0 {
@@ -52,16 +87,12 @@ impl Eal {
         }
 
         tracing::info!(parsed_args = ret, "DPDK EAL initialized");
-        Ok(Self { _args: c_args })
-    }
-}
-
-impl Drop for Eal {
-    fn drop(&mut self) {
-        // SAFETY: EAL was successfully initialized in `init`.
-        unsafe {
-            ffi::rte_eal_cleanup();
-        }
-        tracing::info!("DPDK EAL cleaned up");
+        let inner = Arc::new(EalInner { _args: c_args });
+        // If another thread raced us, OnceLock handles dedup; the
+        // extra EalInner drops harmlessly (cleanup already done).
+        let shared = EAL_INNER.get_or_init(|| inner);
+        Ok(Self {
+            _inner: Arc::clone(shared),
+        })
     }
 }

--- a/ironsbe-transport-dpdk/src/ffi.rs
+++ b/ironsbe-transport-dpdk/src/ffi.rs
@@ -1,0 +1,186 @@
+//! Minimal hand-written FFI declarations for the DPDK functions used
+//! by this crate.
+//!
+//! We declare only the functions we call rather than running `bindgen`
+//! over the full DPDK header tree (~50k lines).  This keeps the build
+//! simple, reproducible, and avoids pulling in a C compiler at build
+//! time for bindgen.
+//!
+//! All types and constants are compatible with DPDK 23.11 LTS.
+
+#![allow(non_camel_case_types)]
+
+use std::os::raw::{c_char, c_int, c_uint, c_void};
+
+// =====================================================================
+// Opaque types — we only ever pass pointers, never inspect fields.
+// =====================================================================
+
+/// Opaque mempool.
+#[repr(C)]
+pub struct rte_mempool {
+    _opaque: [u8; 0],
+}
+
+/// Opaque mbuf (message buffer / packet).
+#[repr(C)]
+pub struct rte_mbuf {
+    _opaque: [u8; 0],
+}
+
+/// Ethernet device configuration.
+#[repr(C)]
+#[derive(Default)]
+pub struct rte_eth_conf {
+    /// We zero-init the entire struct (440 bytes in DPDK 23.11) and
+    /// let DPDK fill defaults.  The struct is large and mostly
+    /// zero-initialised in practice.
+    pub _pad: [u8; 512],
+}
+
+/// Ethernet device info (returned by `rte_eth_dev_info_get`).
+#[repr(C)]
+pub struct rte_eth_dev_info {
+    pub _pad: [u8; 512],
+}
+
+// =====================================================================
+// EAL
+// =====================================================================
+
+extern "C" {
+    /// Initialise the DPDK EAL (Environment Abstraction Layer).
+    ///
+    /// Must be called exactly once, before any other DPDK function.
+    /// Returns the number of parsed args on success, or a negative
+    /// errno on failure.
+    pub fn rte_eal_init(argc: c_int, argv: *mut *mut c_char) -> c_int;
+
+    /// Cleanly shut down the EAL.
+    pub fn rte_eal_cleanup() -> c_int;
+
+    /// Returns the NUMA socket id of the calling lcore.
+    pub fn rte_socket_id() -> c_uint;
+}
+
+// =====================================================================
+// Mempool
+// =====================================================================
+
+extern "C" {
+    /// Creates a mempool for packet buffers (mbufs).
+    pub fn rte_pktmbuf_pool_create(
+        name: *const c_char,
+        n: c_uint,
+        cache_size: c_uint,
+        priv_size: u16,
+        data_room_size: u16,
+        socket_id: c_int,
+    ) -> *mut rte_mempool;
+
+    /// Frees a mempool.
+    pub fn rte_mempool_free(mp: *mut rte_mempool);
+}
+
+// =====================================================================
+// Ethdev — port configuration and rx/tx
+// =====================================================================
+
+extern "C" {
+    /// Returns the number of available ethernet ports.
+    pub fn rte_eth_dev_count_avail() -> u16;
+
+    /// Configures an ethernet device.
+    pub fn rte_eth_dev_configure(
+        port_id: u16,
+        nb_rx_queue: u16,
+        nb_tx_queue: u16,
+        eth_conf: *const rte_eth_conf,
+    ) -> c_int;
+
+    /// Sets up an RX queue.
+    pub fn rte_eth_rx_queue_setup(
+        port_id: u16,
+        rx_queue_id: u16,
+        nb_rx_desc: u16,
+        socket_id: c_uint,
+        rx_conf: *const c_void, // NULL for defaults
+        mb_pool: *mut rte_mempool,
+    ) -> c_int;
+
+    /// Sets up a TX queue.
+    pub fn rte_eth_tx_queue_setup(
+        port_id: u16,
+        tx_queue_id: u16,
+        nb_tx_desc: u16,
+        socket_id: c_uint,
+        tx_conf: *const c_void, // NULL for defaults
+    ) -> c_int;
+
+    /// Starts the ethernet device.
+    pub fn rte_eth_dev_start(port_id: u16) -> c_int;
+
+    /// Stops the ethernet device.
+    pub fn rte_eth_dev_stop(port_id: u16) -> c_int;
+
+    /// Retrieves a burst of input packets from an RX queue.
+    pub fn rte_eth_rx_burst(
+        port_id: u16,
+        queue_id: u16,
+        rx_pkts: *mut *mut rte_mbuf,
+        nb_pkts: u16,
+    ) -> u16;
+
+    /// Sends a burst of output packets on a TX queue.
+    pub fn rte_eth_tx_burst(
+        port_id: u16,
+        queue_id: u16,
+        tx_pkts: *mut *mut rte_mbuf,
+        nb_pkts: u16,
+    ) -> u16;
+
+    /// Promiscuous mode enable.
+    pub fn rte_eth_promiscuous_enable(port_id: u16) -> c_int;
+}
+
+// =====================================================================
+// Mbuf access
+// =====================================================================
+
+extern "C" {
+    /// Allocates an mbuf from a mempool.
+    pub fn rte_pktmbuf_alloc(pool: *mut rte_mempool) -> *mut rte_mbuf;
+
+    /// Frees an mbuf back to its pool.
+    pub fn rte_pktmbuf_free(m: *mut rte_mbuf);
+
+    /// Returns a pointer to the start of the data in the mbuf.
+    ///
+    /// Note: in DPDK this is actually an inline function / macro
+    /// (`rte_pktmbuf_mtod`).  We use the underlying field access
+    /// through [`mbuf_data_ptr`] below instead.
+    pub fn rte_pktmbuf_append(m: *mut rte_mbuf, len: u16) -> *mut c_char;
+
+    /// Returns the data length of the mbuf.
+    pub fn rte_pktmbuf_data_len(m: *const rte_mbuf) -> u16;
+}
+
+/// Reads the raw data pointer from an mbuf by computing the
+/// `buf_addr + data_off` offset.
+///
+/// # Safety
+/// `m` must be a valid, non-null mbuf pointer.  The returned slice
+/// is valid for `rte_pktmbuf_data_len(m)` bytes.
+#[inline]
+pub unsafe fn mbuf_data_ptr(m: *const rte_mbuf) -> *const u8 {
+    // rte_mbuf layout (DPDK 23.11):
+    //   offset 0:   buf_addr  (*mut c_void)
+    //   offset 8:   buf_iova  (u64)
+    //   offset 16:  rearm_data ...
+    //   offset 16+2: data_off (u16)
+    //
+    // rte_pktmbuf_mtod(m) = (char*)m->buf_addr + m->data_off
+    let buf_addr = *(m as *const *const u8);
+    let data_off = *((m as *const u8).add(18) as *const u16);
+    buf_addr.add(data_off as usize)
+}

--- a/ironsbe-transport-dpdk/src/ffi.rs
+++ b/ironsbe-transport-dpdk/src/ffi.rs
@@ -127,6 +127,9 @@ unsafe extern "C" {
     /// Stops the ethernet device.
     pub fn rte_eth_dev_stop(port_id: u16) -> c_int;
 
+    /// Closes the ethernet device and releases its resources.
+    pub fn rte_eth_dev_close(port_id: u16) -> c_int;
+
     /// Retrieves a burst of input packets from an RX queue.
     pub fn rte_eth_rx_burst(
         port_id: u16,

--- a/ironsbe-transport-dpdk/src/ffi.rs
+++ b/ironsbe-transport-dpdk/src/ffi.rs
@@ -29,13 +29,17 @@ pub struct rte_mbuf {
 }
 
 /// Ethernet device configuration.
+///
+/// We zero-init the entire struct and let DPDK fill defaults.
 #[repr(C)]
-#[derive(Default)]
 pub struct rte_eth_conf {
-    /// We zero-init the entire struct (440 bytes in DPDK 23.11) and
-    /// let DPDK fill defaults.  The struct is large and mostly
-    /// zero-initialised in practice.
     pub _pad: [u8; 512],
+}
+
+impl Default for rte_eth_conf {
+    fn default() -> Self {
+        Self { _pad: [0u8; 512] }
+    }
 }
 
 /// Ethernet device info (returned by `rte_eth_dev_info_get`).
@@ -48,7 +52,7 @@ pub struct rte_eth_dev_info {
 // EAL
 // =====================================================================
 
-extern "C" {
+unsafe extern "C" {
     /// Initialise the DPDK EAL (Environment Abstraction Layer).
     ///
     /// Must be called exactly once, before any other DPDK function.
@@ -67,7 +71,7 @@ extern "C" {
 // Mempool
 // =====================================================================
 
-extern "C" {
+unsafe extern "C" {
     /// Creates a mempool for packet buffers (mbufs).
     pub fn rte_pktmbuf_pool_create(
         name: *const c_char,
@@ -86,7 +90,7 @@ extern "C" {
 // Ethdev — port configuration and rx/tx
 // =====================================================================
 
-extern "C" {
+unsafe extern "C" {
     /// Returns the number of available ethernet ports.
     pub fn rte_eth_dev_count_avail() -> u16;
 
@@ -147,7 +151,7 @@ extern "C" {
 // Mbuf access
 // =====================================================================
 
-extern "C" {
+unsafe extern "C" {
     /// Allocates an mbuf from a mempool.
     pub fn rte_pktmbuf_alloc(pool: *mut rte_mempool) -> *mut rte_mbuf;
 
@@ -180,7 +184,9 @@ pub unsafe fn mbuf_data_ptr(m: *const rte_mbuf) -> *const u8 {
     //   offset 16+2: data_off (u16)
     //
     // rte_pktmbuf_mtod(m) = (char*)m->buf_addr + m->data_off
-    let buf_addr = *(m as *const *const u8);
-    let data_off = *((m as *const u8).add(18) as *const u16);
-    buf_addr.add(data_off as usize)
+    unsafe {
+        let buf_addr = *(m as *const *const u8);
+        let data_off = *((m as *const u8).add(18) as *const u16);
+        buf_addr.add(data_off as usize)
+    }
 }

--- a/ironsbe-transport-dpdk/src/lib.rs
+++ b/ironsbe-transport-dpdk/src/lib.rs
@@ -1,0 +1,42 @@
+//! # IronSBE DPDK Transport
+//!
+//! DPDK-based transport backend for IronSBE.  Uses the
+//! [DPDK](https://www.dpdk.org/) poll-mode driver framework for
+//! kernel-bypass packet I/O.
+//!
+//! **This crate is Linux-only and requires `libdpdk-dev` ≥ 23.11
+//! installed on the build machine.**  It is NOT built by default in
+//! the IronSBE workspace — opt in explicitly:
+//!
+//! ```sh
+//! cargo build -p ironsbe-transport-dpdk
+//! ```
+//!
+//! # AF_XDP PMD mode
+//!
+//! The recommended deployment for hosts with a single NIC uses DPDK's
+//! `net_af_xdp` poll-mode driver, which creates a virtual DPDK port
+//! backed by an AF_XDP socket on an existing kernel NIC.  The NIC
+//! stays in the kernel (SSH/monitoring keep working) while the
+//! datapath gets DPDK's burst API, mempool, and lcore model.
+//!
+//! ```text
+//! EAL args: ["ironsbe", "--no-huge", "--proc-type=primary",
+//!            "--vdev=net_af_xdp0,iface=eth0,start_queue=0,queue_count=1"]
+//! ```
+//!
+//! # Native DPDK PMD mode
+//!
+//! For dedicated NICs bound to `vfio-pci`, omit the `--vdev` argument
+//! and let EAL auto-detect the PCI device.  This gives the lowest
+//! latency but requires hugepages, NIC unbinding, and core isolation.
+//! See `docs/transport-backends.md` for the full operational checklist.
+
+pub mod eal;
+pub mod ffi;
+pub mod port;
+pub mod transport;
+
+pub use eal::Eal;
+pub use port::DpdkPort;
+pub use transport::{DpdkConfig, DpdkListener, DpdkTransport};

--- a/ironsbe-transport-dpdk/src/lib.rs
+++ b/ironsbe-transport-dpdk/src/lib.rs
@@ -32,6 +32,14 @@
 //! latency but requires hugepages, NIC unbinding, and core isolation.
 //! See `docs/transport-backends.md` for the full operational checklist.
 
+// Fail fast on non-Linux with a clear message rather than opaque
+// linker errors.
+#[cfg(not(target_os = "linux"))]
+compile_error!(
+    "ironsbe-transport-dpdk is Linux-only. \
+     It requires libdpdk-dev (DPDK 23.11+) which is not available on this platform."
+);
+
 pub mod eal;
 pub mod ffi;
 pub mod port;

--- a/ironsbe-transport-dpdk/src/port.rs
+++ b/ironsbe-transport-dpdk/src/port.rs
@@ -159,10 +159,11 @@ impl Drop for DpdkPort {
     fn drop(&mut self) {
         unsafe {
             let _ = ffi::rte_eth_dev_stop(self.port_id);
+            let _ = ffi::rte_eth_dev_close(self.port_id);
             if !self.pool.is_null() {
                 ffi::rte_mempool_free(self.pool);
             }
         }
-        tracing::info!(port_id = self.port_id, "DPDK port stopped");
+        tracing::info!(port_id = self.port_id, "DPDK port stopped and closed");
     }
 }

--- a/ironsbe-transport-dpdk/src/port.rs
+++ b/ironsbe-transport-dpdk/src/port.rs
@@ -53,8 +53,7 @@ impl DpdkPort {
         let socket_id = unsafe { ffi::rte_socket_id() };
 
         // Create mbuf pool.
-        let pool_name =
-            CString::new("MBUF_POOL").map_err(io::Error::other)?;
+        let pool_name = CString::new("MBUF_POOL").map_err(io::Error::other)?;
         let pool = unsafe {
             ffi::rte_pktmbuf_pool_create(
                 pool_name.as_ptr(),
@@ -66,18 +65,16 @@ impl DpdkPort {
             )
         };
         if pool.is_null() {
-            return Err(io::Error::other(
-                "rte_pktmbuf_pool_create returned NULL",
-            ));
+            return Err(io::Error::other("rte_pktmbuf_pool_create returned NULL"));
         }
 
         // Configure the port with 1 rx + 1 tx queue.
         let eth_conf = ffi::rte_eth_conf::default();
         let ret = unsafe { ffi::rte_eth_dev_configure(port_id, 1, 1, &eth_conf) };
         if ret != 0 {
-            return Err(io::Error::other(
-                format!("rte_eth_dev_configure failed: {ret}"),
-            ));
+            return Err(io::Error::other(format!(
+                "rte_eth_dev_configure failed: {ret}"
+            )));
         }
 
         // Setup rx queue.
@@ -85,9 +82,9 @@ impl DpdkPort {
             ffi::rte_eth_rx_queue_setup(port_id, 0, DEFAULT_NB_DESC, socket_id, ptr::null(), pool)
         };
         if ret != 0 {
-            return Err(io::Error::other(
-                format!("rte_eth_rx_queue_setup failed: {ret}"),
-            ));
+            return Err(io::Error::other(format!(
+                "rte_eth_rx_queue_setup failed: {ret}"
+            )));
         }
 
         // Setup tx queue.
@@ -95,9 +92,9 @@ impl DpdkPort {
             ffi::rte_eth_tx_queue_setup(port_id, 0, DEFAULT_NB_DESC, socket_id, ptr::null())
         };
         if ret != 0 {
-            return Err(io::Error::other(
-                format!("rte_eth_tx_queue_setup failed: {ret}"),
-            ));
+            return Err(io::Error::other(format!(
+                "rte_eth_tx_queue_setup failed: {ret}"
+            )));
         }
 
         // Enable promiscuous mode (receive all packets, important for
@@ -110,9 +107,7 @@ impl DpdkPort {
         // Start the port.
         let ret = unsafe { ffi::rte_eth_dev_start(port_id) };
         if ret != 0 {
-            return Err(io::Error::other(
-                format!("rte_eth_dev_start failed: {ret}"),
-            ));
+            return Err(io::Error::other(format!("rte_eth_dev_start failed: {ret}")));
         }
 
         tracing::info!(port_id, "DPDK port started");

--- a/ironsbe-transport-dpdk/src/port.rs
+++ b/ironsbe-transport-dpdk/src/port.rs
@@ -54,7 +54,7 @@ impl DpdkPort {
 
         // Create mbuf pool.
         let pool_name =
-            CString::new("MBUF_POOL").map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            CString::new("MBUF_POOL").map_err(io::Error::other)?;
         let pool = unsafe {
             ffi::rte_pktmbuf_pool_create(
                 pool_name.as_ptr(),
@@ -66,8 +66,7 @@ impl DpdkPort {
             )
         };
         if pool.is_null() {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
+            return Err(io::Error::other(
                 "rte_pktmbuf_pool_create returned NULL",
             ));
         }
@@ -76,8 +75,7 @@ impl DpdkPort {
         let eth_conf = ffi::rte_eth_conf::default();
         let ret = unsafe { ffi::rte_eth_dev_configure(port_id, 1, 1, &eth_conf) };
         if ret != 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
+            return Err(io::Error::other(
                 format!("rte_eth_dev_configure failed: {ret}"),
             ));
         }
@@ -87,8 +85,7 @@ impl DpdkPort {
             ffi::rte_eth_rx_queue_setup(port_id, 0, DEFAULT_NB_DESC, socket_id, ptr::null(), pool)
         };
         if ret != 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
+            return Err(io::Error::other(
                 format!("rte_eth_rx_queue_setup failed: {ret}"),
             ));
         }
@@ -98,8 +95,7 @@ impl DpdkPort {
             ffi::rte_eth_tx_queue_setup(port_id, 0, DEFAULT_NB_DESC, socket_id, ptr::null())
         };
         if ret != 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
+            return Err(io::Error::other(
                 format!("rte_eth_tx_queue_setup failed: {ret}"),
             ));
         }
@@ -114,8 +110,7 @@ impl DpdkPort {
         // Start the port.
         let ret = unsafe { ffi::rte_eth_dev_start(port_id) };
         if ret != 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
+            return Err(io::Error::other(
                 format!("rte_eth_dev_start failed: {ret}"),
             ));
         }

--- a/ironsbe-transport-dpdk/src/port.rs
+++ b/ironsbe-transport-dpdk/src/port.rs
@@ -1,0 +1,187 @@
+//! DPDK port (ethdev) configuration and rx/tx burst helpers.
+//!
+//! A "port" in DPDK terms is a network interface managed by a
+//! poll-mode driver (PMD).  When using the `net_af_xdp` PMD the port
+//! represents an AF_XDP socket on an existing kernel NIC — the NIC
+//! stays in the kernel and is shared.
+
+use crate::ffi;
+use std::ffi::CString;
+use std::io;
+use std::ptr;
+
+/// Maximum burst size for rx/tx operations.
+pub const MAX_BURST: usize = 32;
+
+/// Default number of descriptors per rx/tx queue.
+const DEFAULT_NB_DESC: u16 = 1024;
+
+/// Default mbuf pool size.
+const DEFAULT_POOL_SIZE: u32 = 8191;
+
+/// Default per-core mbuf cache size.
+const DEFAULT_CACHE_SIZE: u32 = 250;
+
+/// Default mbuf data room size (headroom + MTU).
+const DEFAULT_DATA_ROOM: u16 = 2048 + 128; // RTE_PKTMBUF_HEADROOM + MTU
+
+/// A configured DPDK port with one rx and one tx queue.
+pub struct DpdkPort {
+    port_id: u16,
+    pool: *mut ffi::rte_mempool,
+}
+
+impl DpdkPort {
+    /// Configures and starts the first available DPDK port.
+    ///
+    /// After EAL init with a `--vdev=net_af_xdp0,...` argument, this
+    /// function finds port 0, creates a mempool, sets up one rx + one
+    /// tx queue, enables promiscuous mode, and starts the port.
+    ///
+    /// # Errors
+    /// Returns an `io::Error` if any DPDK call fails.
+    pub fn init() -> io::Result<Self> {
+        let nb_ports = unsafe { ffi::rte_eth_dev_count_avail() };
+        if nb_ports == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "no DPDK ports available (did you pass --vdev=net_af_xdp0,...?)",
+            ));
+        }
+
+        let port_id: u16 = 0;
+        let socket_id = unsafe { ffi::rte_socket_id() };
+
+        // Create mbuf pool.
+        let pool_name =
+            CString::new("MBUF_POOL").map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        let pool = unsafe {
+            ffi::rte_pktmbuf_pool_create(
+                pool_name.as_ptr(),
+                DEFAULT_POOL_SIZE,
+                DEFAULT_CACHE_SIZE,
+                0,
+                DEFAULT_DATA_ROOM,
+                socket_id as i32,
+            )
+        };
+        if pool.is_null() {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "rte_pktmbuf_pool_create returned NULL",
+            ));
+        }
+
+        // Configure the port with 1 rx + 1 tx queue.
+        let eth_conf = ffi::rte_eth_conf::default();
+        let ret = unsafe { ffi::rte_eth_dev_configure(port_id, 1, 1, &eth_conf) };
+        if ret != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("rte_eth_dev_configure failed: {ret}"),
+            ));
+        }
+
+        // Setup rx queue.
+        let ret = unsafe {
+            ffi::rte_eth_rx_queue_setup(
+                port_id,
+                0,
+                DEFAULT_NB_DESC,
+                socket_id,
+                ptr::null(),
+                pool,
+            )
+        };
+        if ret != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("rte_eth_rx_queue_setup failed: {ret}"),
+            ));
+        }
+
+        // Setup tx queue.
+        let ret = unsafe {
+            ffi::rte_eth_tx_queue_setup(port_id, 0, DEFAULT_NB_DESC, socket_id, ptr::null())
+        };
+        if ret != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("rte_eth_tx_queue_setup failed: {ret}"),
+            ));
+        }
+
+        // Enable promiscuous mode (receive all packets, important for
+        // AF_XDP PMD to see traffic for our MAC/IP).
+        let ret = unsafe { ffi::rte_eth_promiscuous_enable(port_id) };
+        if ret != 0 {
+            tracing::warn!("rte_eth_promiscuous_enable failed: {ret} (non-fatal)");
+        }
+
+        // Start the port.
+        let ret = unsafe { ffi::rte_eth_dev_start(port_id) };
+        if ret != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("rte_eth_dev_start failed: {ret}"),
+            ));
+        }
+
+        tracing::info!(port_id, "DPDK port started");
+        Ok(Self { port_id, pool })
+    }
+
+    /// Returns the port id.
+    #[must_use]
+    pub fn port_id(&self) -> u16 {
+        self.port_id
+    }
+
+    /// Returns the mbuf pool pointer (needed for allocating tx mbufs).
+    #[must_use]
+    pub fn pool(&self) -> *mut ffi::rte_mempool {
+        self.pool
+    }
+
+    /// Receives a burst of packets from the rx queue.
+    ///
+    /// Returns the number of packets received (≤ `MAX_BURST`).  The
+    /// caller must process and free the mbufs.
+    ///
+    /// # Safety
+    /// `pkts` must point to an array of at least `MAX_BURST` mbuf
+    /// pointers.
+    #[inline]
+    pub unsafe fn rx_burst(&self, pkts: &mut [*mut ffi::rte_mbuf; MAX_BURST]) -> u16 {
+        // SAFETY: caller guarantees the array is large enough.
+        unsafe {
+            ffi::rte_eth_rx_burst(self.port_id, 0, pkts.as_mut_ptr(), MAX_BURST as u16)
+        }
+    }
+
+    /// Sends a burst of packets on the tx queue.
+    ///
+    /// Returns the number of packets successfully enqueued.  The
+    /// caller must free any mbufs that were NOT sent (i.e.
+    /// `pkts[sent..nb_pkts]`).
+    ///
+    /// # Safety
+    /// `pkts` must contain valid mbuf pointers.
+    #[inline]
+    pub unsafe fn tx_burst(&self, pkts: &mut [*mut ffi::rte_mbuf], nb_pkts: u16) -> u16 {
+        // SAFETY: caller guarantees valid mbuf pointers.
+        unsafe { ffi::rte_eth_tx_burst(self.port_id, 0, pkts.as_mut_ptr(), nb_pkts) }
+    }
+}
+
+impl Drop for DpdkPort {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = ffi::rte_eth_dev_stop(self.port_id);
+            if !self.pool.is_null() {
+                ffi::rte_mempool_free(self.pool);
+            }
+        }
+        tracing::info!(port_id = self.port_id, "DPDK port stopped");
+    }
+}

--- a/ironsbe-transport-dpdk/src/port.rs
+++ b/ironsbe-transport-dpdk/src/port.rs
@@ -84,14 +84,7 @@ impl DpdkPort {
 
         // Setup rx queue.
         let ret = unsafe {
-            ffi::rte_eth_rx_queue_setup(
-                port_id,
-                0,
-                DEFAULT_NB_DESC,
-                socket_id,
-                ptr::null(),
-                pool,
-            )
+            ffi::rte_eth_rx_queue_setup(port_id, 0, DEFAULT_NB_DESC, socket_id, ptr::null(), pool)
         };
         if ret != 0 {
             return Err(io::Error::new(
@@ -154,9 +147,7 @@ impl DpdkPort {
     #[inline]
     pub unsafe fn rx_burst(&self, pkts: &mut [*mut ffi::rte_mbuf; MAX_BURST]) -> u16 {
         // SAFETY: caller guarantees the array is large enough.
-        unsafe {
-            ffi::rte_eth_rx_burst(self.port_id, 0, pkts.as_mut_ptr(), MAX_BURST as u16)
-        }
+        unsafe { ffi::rte_eth_rx_burst(self.port_id, 0, pkts.as_mut_ptr(), MAX_BURST as u16) }
     }
 
     /// Sends a burst of packets on the tx queue.

--- a/ironsbe-transport-dpdk/src/transport.rs
+++ b/ironsbe-transport-dpdk/src/transport.rs
@@ -1,0 +1,227 @@
+//! High-level [`LocalTransport`] implementation for the DPDK backend.
+//!
+//! `DpdkTransport<S>` ties together DPDK EAL + port + a user-selected
+//! [`XdpStack`] into a single type usable by `LocalServer`.
+//!
+//! The DPDK datapath runs a busy-poll loop calling
+//! `rte_eth_rx_burst` / `rte_eth_tx_burst` and feeding received
+//! frames into the stack's `on_rx`.
+
+use crate::eal::Eal;
+use crate::ffi;
+use crate::port::{DpdkPort, MAX_BURST};
+use ironsbe_transport::traits::{LocalListener, LocalTransport};
+use ironsbe_transport::xdp::stack::{FrameTxQueue, XdpStack};
+use std::ffi::CString;
+use std::io;
+use std::marker::PhantomData;
+use std::net::{IpAddr, SocketAddr};
+
+/// Configuration for [`DpdkTransport`].
+#[derive(Debug, Clone)]
+pub struct DpdkConfig<S> {
+    /// EAL arguments passed to `rte_eal_init`.
+    ///
+    /// Must include a `--vdev=net_af_xdp0,iface=<iface>,...` argument
+    /// for the AF_XDP PMD mode.  Example:
+    ///
+    /// ```text
+    /// ["ironsbe", "--no-huge", "--proc-type=primary",
+    ///  "--vdev=net_af_xdp0,iface=eth0,start_queue=0,queue_count=1"]
+    /// ```
+    pub eal_args: Vec<String>,
+    /// The userspace stack (same trait as the XDP backend).
+    pub stack: S,
+    /// Listen port (for `local_addr()` reporting).
+    pub listen_port: u16,
+}
+
+impl<S: Clone> DpdkConfig<S> {
+    /// Creates a new DPDK config.
+    #[must_use]
+    pub fn new(eal_args: Vec<String>, stack: S, listen_port: u16) -> Self {
+        Self {
+            eal_args,
+            stack,
+            listen_port,
+        }
+    }
+}
+
+/// Fallback `From<SocketAddr>` — builds a minimal AF_XDP PMD config
+/// on `lo`.  Only useful for tests; production callers should construct
+/// an explicit [`DpdkConfig`].
+impl From<SocketAddr> for DpdkConfig<ironsbe_transport::xdp::UdpStack> {
+    fn from(addr: SocketAddr) -> Self {
+        use ironsbe_transport::xdp::stack::udp::UdpStackConfig;
+        let ip = match addr.ip() {
+            IpAddr::V4(v4) => v4,
+            IpAddr::V6(_) => std::net::Ipv4Addr::LOCALHOST,
+        };
+        let mac = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
+        let stack = ironsbe_transport::xdp::UdpStack::new(UdpStackConfig::new(
+            ip,
+            addr.port(),
+            mac,
+        ));
+        Self {
+            eal_args: vec![
+                "ironsbe".into(),
+                "--no-huge".into(),
+                "--proc-type=primary".into(),
+                "--vdev=net_af_xdp0,iface=lo,start_queue=0,queue_count=1".into(),
+            ],
+            stack,
+            listen_port: addr.port(),
+        }
+    }
+}
+
+/// DPDK transport backend.
+///
+/// Generic over the userspace stack `S` (reuses the same [`XdpStack`]
+/// trait as the AF_XDP backend, since both operate on raw Ethernet
+/// frames).
+pub struct DpdkTransport<S: XdpStack>(PhantomData<S>);
+
+impl<S> LocalTransport for DpdkTransport<S>
+where
+    S: XdpStack + Clone + 'static,
+    S::Connection: 'static,
+    S::Error: std::fmt::Display + 'static,
+    DpdkConfig<S>: From<SocketAddr> + Clone + 'static,
+{
+    type Listener = DpdkListener<S>;
+    type Connection = S::Connection;
+    type Error = io::Error;
+    type BindConfig = DpdkConfig<S>;
+    type ConnectConfig = DpdkConfig<S>;
+
+    async fn bind_with(config: DpdkConfig<S>) -> io::Result<DpdkListener<S>> {
+        let arg_refs: Vec<&str> = config.eal_args.iter().map(|s| s.as_str()).collect();
+        let eal = Eal::init(&arg_refs)?;
+        let port = DpdkPort::init()?;
+        let local_ip = config.stack.local_ip();
+        let listen_port = config.listen_port;
+        Ok(DpdkListener {
+            _eal: eal,
+            port,
+            stack: config.stack,
+            local_addr: SocketAddr::new(local_ip, listen_port),
+            pending_conns: std::collections::VecDeque::new(),
+        })
+    }
+
+    async fn connect_with(_config: DpdkConfig<S>) -> io::Result<S::Connection> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "DPDK does not support client-side connect; \
+             use a regular TCP/UDP client",
+        ))
+    }
+}
+
+/// DPDK listener that busy-polls `rte_eth_rx_burst` and feeds frames
+/// to the selected stack until a new connection is yielded.
+pub struct DpdkListener<S: XdpStack> {
+    _eal: Eal,
+    port: DpdkPort,
+    stack: S,
+    local_addr: SocketAddr,
+    pending_conns: std::collections::VecDeque<S::Connection>,
+}
+
+impl<S> LocalListener for DpdkListener<S>
+where
+    S: XdpStack + 'static,
+    S::Connection: 'static,
+    S::Error: std::fmt::Display + 'static,
+{
+    type Connection = S::Connection;
+    type Error = io::Error;
+
+    async fn accept(&mut self) -> io::Result<S::Connection> {
+        loop {
+            if let Some(conn) = self.pending_conns.pop_front() {
+                return Ok(conn);
+            }
+
+            // rx burst
+            let mut rx_pkts: [*mut ffi::rte_mbuf; MAX_BURST] =
+                [std::ptr::null_mut(); MAX_BURST];
+            // SAFETY: rx_pkts is a valid array of MAX_BURST pointers.
+            let nb_rx = unsafe { self.port.rx_burst(&mut rx_pkts) };
+
+            let mut tx_buf: Vec<Vec<u8>> = Vec::new();
+
+            for i in 0..nb_rx as usize {
+                let mbuf = rx_pkts[i];
+                // SAFETY: mbuf was just returned by rte_eth_rx_burst
+                // and is valid until we free it.
+                let (data_ptr, data_len) = unsafe {
+                    let ptr = ffi::mbuf_data_ptr(mbuf);
+                    let len = ffi::rte_pktmbuf_data_len(mbuf);
+                    (ptr, len as usize)
+                };
+                let frame = unsafe { std::slice::from_raw_parts(data_ptr, data_len) };
+
+                let mut q = FrameTxQueue::new(&mut tx_buf);
+                if let Some(conn) = self
+                    .stack
+                    .on_rx(frame, &mut q)
+                    .map_err(|e| io::Error::other(e.to_string()))?
+                {
+                    self.pending_conns.push_back(conn);
+                }
+
+                // Free the mbuf.
+                // SAFETY: we are done reading this mbuf.
+                unsafe {
+                    ffi::rte_pktmbuf_free(mbuf);
+                }
+            }
+
+            // tx burst: send any frames the stack produced.
+            for frame_data in &tx_buf {
+                // Allocate a fresh mbuf for each outbound frame.
+                let mbuf = unsafe { ffi::rte_pktmbuf_alloc(self.port.pool()) };
+                if mbuf.is_null() {
+                    tracing::warn!("dpdk: rte_pktmbuf_alloc returned null, dropping tx frame");
+                    continue;
+                }
+                // SAFETY: mbuf is freshly allocated and valid.
+                let data_ptr = unsafe {
+                    ffi::rte_pktmbuf_append(mbuf, frame_data.len() as u16)
+                };
+                if data_ptr.is_null() {
+                    tracing::warn!("dpdk: rte_pktmbuf_append returned null (frame too large?)");
+                    unsafe { ffi::rte_pktmbuf_free(mbuf); }
+                    continue;
+                }
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        frame_data.as_ptr(),
+                        data_ptr as *mut u8,
+                        frame_data.len(),
+                    );
+                }
+                let mut pkts = [mbuf];
+                // SAFETY: pkts contains a valid mbuf.
+                let sent = unsafe { self.port.tx_burst(&mut pkts, 1) };
+                if sent == 0 {
+                    // Free unsent mbuf.
+                    unsafe { ffi::rte_pktmbuf_free(mbuf); }
+                }
+            }
+
+            // Yield when idle.
+            if nb_rx == 0 {
+                tokio::task::yield_now().await;
+            }
+        }
+    }
+
+    fn local_addr(&self) -> io::Result<SocketAddr> {
+        Ok(self.local_addr)
+    }
+}

--- a/ironsbe-transport-dpdk/src/transport.rs
+++ b/ironsbe-transport-dpdk/src/transport.rs
@@ -12,7 +12,6 @@ use crate::ffi;
 use crate::port::{DpdkPort, MAX_BURST};
 use ironsbe_transport::traits::{LocalListener, LocalTransport};
 use ironsbe_transport::xdp::stack::{FrameTxQueue, XdpStack};
-use std::ffi::CString;
 use std::io;
 use std::marker::PhantomData;
 use std::net::{IpAddr, SocketAddr};
@@ -59,11 +58,8 @@ impl From<SocketAddr> for DpdkConfig<ironsbe_transport::xdp::UdpStack> {
             IpAddr::V6(_) => std::net::Ipv4Addr::LOCALHOST,
         };
         let mac = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
-        let stack = ironsbe_transport::xdp::UdpStack::new(UdpStackConfig::new(
-            ip,
-            addr.port(),
-            mac,
-        ));
+        let stack =
+            ironsbe_transport::xdp::UdpStack::new(UdpStackConfig::new(ip, addr.port(), mac));
         Self {
             eal_args: vec![
                 "ironsbe".into(),
@@ -147,8 +143,7 @@ where
             }
 
             // rx burst
-            let mut rx_pkts: [*mut ffi::rte_mbuf; MAX_BURST] =
-                [std::ptr::null_mut(); MAX_BURST];
+            let mut rx_pkts: [*mut ffi::rte_mbuf; MAX_BURST] = [std::ptr::null_mut(); MAX_BURST];
             // SAFETY: rx_pkts is a valid array of MAX_BURST pointers.
             let nb_rx = unsafe { self.port.rx_burst(&mut rx_pkts) };
 
@@ -190,12 +185,12 @@ where
                     continue;
                 }
                 // SAFETY: mbuf is freshly allocated and valid.
-                let data_ptr = unsafe {
-                    ffi::rte_pktmbuf_append(mbuf, frame_data.len() as u16)
-                };
+                let data_ptr = unsafe { ffi::rte_pktmbuf_append(mbuf, frame_data.len() as u16) };
                 if data_ptr.is_null() {
                     tracing::warn!("dpdk: rte_pktmbuf_append returned null (frame too large?)");
-                    unsafe { ffi::rte_pktmbuf_free(mbuf); }
+                    unsafe {
+                        ffi::rte_pktmbuf_free(mbuf);
+                    }
                     continue;
                 }
                 unsafe {
@@ -210,7 +205,9 @@ where
                 let sent = unsafe { self.port.tx_burst(&mut pkts, 1) };
                 if sent == 0 {
                     // Free unsent mbuf.
-                    unsafe { ffi::rte_pktmbuf_free(mbuf); }
+                    unsafe {
+                        ffi::rte_pktmbuf_free(mbuf);
+                    }
                 }
             }
 

--- a/ironsbe-transport-dpdk/src/transport.rs
+++ b/ironsbe-transport-dpdk/src/transport.rs
@@ -149,8 +149,7 @@ where
 
             let mut tx_buf: Vec<Vec<u8>> = Vec::new();
 
-            for i in 0..nb_rx as usize {
-                let mbuf = rx_pkts[i];
+            for &mbuf in rx_pkts.iter().take(nb_rx as usize) {
                 // SAFETY: mbuf was just returned by rte_eth_rx_burst
                 // and is valid until we free it.
                 let (data_ptr, data_len) = unsafe {

--- a/ironsbe-transport-dpdk/src/transport.rs
+++ b/ironsbe-transport-dpdk/src/transport.rs
@@ -175,8 +175,28 @@ where
                 }
             }
 
+            // Let the stack flush timers (smoltcp retransmissions,
+            // ARP refresh, …) even when no frames were received.
+            {
+                let mut q = FrameTxQueue::new(&mut tx_buf);
+                self.stack
+                    .poll_timers(&mut q)
+                    .map_err(|e| io::Error::other(e.to_string()))?;
+            }
+
             // tx burst: send any frames the stack produced.
             for frame_data in &tx_buf {
+                // Validate length fits in u16 before the cast.
+                let len = match u16::try_from(frame_data.len()) {
+                    Ok(l) => l,
+                    Err(_) => {
+                        tracing::warn!(
+                            len = frame_data.len(),
+                            "dpdk: frame exceeds u16::MAX, dropping"
+                        );
+                        continue;
+                    }
+                };
                 // Allocate a fresh mbuf for each outbound frame.
                 let mbuf = unsafe { ffi::rte_pktmbuf_alloc(self.port.pool()) };
                 if mbuf.is_null() {
@@ -184,7 +204,7 @@ where
                     continue;
                 }
                 // SAFETY: mbuf is freshly allocated and valid.
-                let data_ptr = unsafe { ffi::rte_pktmbuf_append(mbuf, frame_data.len() as u16) };
+                let data_ptr = unsafe { ffi::rte_pktmbuf_append(mbuf, len) };
                 if data_ptr.is_null() {
                     tracing::warn!("dpdk: rte_pktmbuf_append returned null (frame too large?)");
                     unsafe {
@@ -203,7 +223,6 @@ where
                 // SAFETY: pkts contains a valid mbuf.
                 let sent = unsafe { self.port.tx_burst(&mut pkts, 1) };
                 if sent == 0 {
-                    // Free unsent mbuf.
                     unsafe {
                         ffi::rte_pktmbuf_free(mbuf);
                     }


### PR DESCRIPTION
## Summary

New crate `ironsbe-transport-dpdk` implementing a DPDK-based transport backend via the `net_af_xdp` poll-mode driver.  Closes #17.

### Why a separate crate

DPDK pulls in heavy C build dependencies (`libdpdk-dev`, `libnuma`, `libpcap`, etc.) and is Linux-only.  Keeping it in a separate crate (in the workspace but NOT in `default-members`) means `cargo build` / `cargo test` of the main workspace is completely unaffected when DPDK is not installed.

### What's in this PR

- **`ironsbe-transport-dpdk/`** — new workspace member with `build.rs` that probes for `libdpdk` via `pkg-config`.
- **`ffi.rs`** — ~20 hand-written `unsafe extern "C"` declarations (EAL, mempool, ethdev, mbuf).  No bindgen, no C compiler at build time.
- **`eal.rs`** — RAII `Eal` guard wrapping `rte_eal_init` / `rte_eal_cleanup`.
- **`port.rs`** — `DpdkPort` for single-queue port config + rx/tx burst wrappers.
- **`transport.rs`** — `DpdkTransport<S: XdpStack>` implementing `LocalTransport`.  Reuses the same `XdpStack` trait + `UdpStack`/`SmoltcpStack` from `ironsbe-transport::xdp::stack` so the L3/L4 layer is shared with the AF_XDP backend.
- **`default-members`** in workspace `Cargo.toml` so `cargo build` skips the dpdk crate.

### AF_XDP PMD mode

The recommended deployment uses `--vdev=net_af_xdp0,iface=eth0,...` which creates a virtual DPDK port backed by an AF_XDP socket on an existing kernel NIC.  The NIC stays in the kernel (SSH/monitoring keep working) while the datapath gets DPDK's burst API, mempool, and lcore model.  Native PMD mode (vfio-pci) is also supported for dedicated NICs.

### Dev loop

Built and validated via SSH to a Linux machine (kernel 6.8.0, DPDK 23.11 LTS from `libdpdk-dev`):

```
cargo clippy -p ironsbe-transport-dpdk -- -D warnings  # clean on Linux
cargo check  # default workspace unaffected on macOS
make pre-push  # clean on macOS
```

## Test plan

- [x] `cargo check` on macOS (dpdk crate excluded from default-members)
- [x] `make pre-push` on macOS
- [x] `cargo check -p ironsbe-transport-dpdk` on Linux (via SSH)
- [x] `cargo clippy -p ironsbe-transport-dpdk -- -D warnings` on Linux (via SSH)
- [ ] CI: default workspace build unaffected (dpdk not in default-members)
- [ ] Runtime test with `sudo` + EAL init (manual, hardware — not in CI)

### Out of scope

- CI job that builds the dpdk crate (would need libdpdk-dev installed in the runner)
- Runtime integration test (needs root + DPDK capabilities)
- Benchmark numbers (needs hardware run)
- Native PMD mode documentation (hugepages, vfio-pci, core isolation)
- Multi-queue / multi-lcore