### PR TITLE
refactor(rdma): server test timeouts + rename RdmaConfig::bind_addr (#50, #51)

### DIFF
--- a/ironsbe-transport-rdma/src/transport.rs
+++ b/ironsbe-transport-rdma/src/transport.rs
@@ -7,10 +7,16 @@ use std::io;
 use std::net::SocketAddr;
 
 /// RDMA transport configuration.
+///
+/// Used for both the listener (bind) and client (connect) sides of
+/// an RDMA CM connection.  The [`addr`](Self::addr) field is the bind
+/// address for [`LocalTransport::bind_with`] and the remote target
+/// for [`LocalTransport::connect_with`].
 #[derive(Debug, Clone)]
 pub struct RdmaConfig {
-    /// Address to bind the RDMA CM listener to.
-    pub bind_addr: SocketAddr,
+    /// Target address — the bind address for listeners, the remote
+    /// endpoint for client connections.
+    pub addr: SocketAddr,
     /// Maximum SBE message size in bytes (excluding the 4-byte length
     /// prefix).
     pub max_msg_size: usize,
@@ -19,18 +25,15 @@ pub struct RdmaConfig {
 impl RdmaConfig {
     /// Creates a new RDMA config.
     #[must_use]
-    pub fn new(bind_addr: SocketAddr, max_msg_size: usize) -> Self {
-        Self {
-            bind_addr,
-            max_msg_size,
-        }
+    pub fn new(addr: SocketAddr, max_msg_size: usize) -> Self {
+        Self { addr, max_msg_size }
     }
 }
 
 impl From<SocketAddr> for RdmaConfig {
     fn from(addr: SocketAddr) -> Self {
         Self {
-            bind_addr: addr,
+            addr,
             max_msg_size: 64 * 1024,
         }
     }
@@ -51,10 +54,10 @@ impl LocalTransport for RdmaTransport {
     type ConnectConfig = RdmaConfig;
 
     async fn bind_with(config: RdmaConfig) -> io::Result<RdmaListener> {
-        RdmaListener::bind(config.bind_addr, config.max_msg_size)
+        RdmaListener::bind(config.addr, config.max_msg_size)
     }
 
     async fn connect_with(config: RdmaConfig) -> io::Result<RdmaConnection> {
-        RdmaConnection::connect(config.bind_addr, config.max_msg_size).await
+        RdmaConnection::connect(config.addr, config.max_msg_size).await
     }
 }

--- a/ironsbe-transport-rdma/tests/loopback.rs
+++ b/ironsbe-transport-rdma/tests/loopback.rs
@@ -5,8 +5,9 @@
 //! RDMA CM event channels on SoftRoCE.
 //!
 //! Every server thread wraps its work in `tokio::time::timeout` so
-//! it cannot hang if the client fails, and `server.join()` is called
-//! on every exit path (success, client timeout, panic).  See #50.
+//! it cannot hang indefinitely if the client fails.  A `JoinGuard`
+//! ensures the server thread is joined even if the client panics
+//! during unwind.  See #50.
 //!
 //! When no RDMA device is available the tests print a message and
 //! return early, so `cargo test` on a host without RDMA succeeds.
@@ -23,6 +24,31 @@ use tokio::time::timeout;
 
 const DEFAULT_MAX_MSG: usize = 64 * 1024;
 const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// RAII guard that joins a thread on drop — even during unwind.
+/// Prevents detached server threads from leaking past the test scope.
+struct JoinGuard(Option<std::thread::JoinHandle<()>>);
+
+impl JoinGuard {
+    fn new(handle: std::thread::JoinHandle<()>) -> Self {
+        Self(Some(handle))
+    }
+
+    /// Consumes the guard, joins the thread, and propagates panics.
+    fn join(mut self) {
+        if let Some(h) = self.0.take() {
+            h.join().expect("server thread panicked");
+        }
+    }
+}
+
+impl Drop for JoinGuard {
+    fn drop(&mut self) {
+        if let Some(h) = self.0.take() {
+            let _ = h.join();
+        }
+    }
+}
 
 fn try_bind_listener(addr: SocketAddr, max_msg: usize) -> Option<RdmaListener> {
     match RdmaListener::bind(addr, max_msg) {
@@ -93,14 +119,15 @@ fn first_non_loopback_ipv4() -> Option<std::net::Ipv4Addr> {
 }
 
 /// Spawns a server on a dedicated OS thread with its own tokio
-/// runtime.  The server binds to `0.0.0.0:0`, sends the bound port
-/// back via `port_tx`, then runs `server_body` inside a
-/// `timeout(TEST_TIMEOUT, ...)`.  If the timeout fires or the body
-/// panics, the thread exits cleanly — no indefinite hang.
+/// runtime.  The server binds, sends the port back, then runs
+/// `server_body` inside `timeout(TEST_TIMEOUT, ...)`.
 ///
-/// Returns `(connect_addr, server_join_handle)`, or `None` if no
-/// RDMA device is available.
-fn spawn_server<F, Fut>(server_body: F) -> Option<(SocketAddr, std::thread::JoinHandle<()>)>
+/// The returned [`JoinGuard`] joins the thread on drop (even during
+/// unwind) so the server thread is never left detached.
+///
+/// Returns `None` (joining the thread on failure) if no RDMA device
+/// or the port handshake fails.
+fn spawn_server<F, Fut>(server_body: F) -> Option<(SocketAddr, JoinGuard)>
 where
     F: FnOnce(RdmaListener) -> Fut + Send + 'static,
     Fut: std::future::Future<Output = ()>,
@@ -125,20 +152,25 @@ where
             };
             let _ = port_tx.send(Some(listener.local_addr().expect("la").port()));
 
-            // Bounded wait — the server thread cannot hang even if
-            // the client never connects.  See #50.
             if timeout(TEST_TIMEOUT, server_body(listener)).await.is_err() {
-                eprintln!("server timed out (no client connected within {TEST_TIMEOUT:?})");
+                eprintln!("server timed out (no client within {TEST_TIMEOUT:?})");
             }
         });
     });
 
-    let port = port_rx
-        .recv_timeout(Duration::from_secs(5))
-        .ok()
-        .flatten()?;
+    let guard = JoinGuard::new(handle);
+
+    let port = match port_rx.recv_timeout(Duration::from_secs(5)) {
+        Ok(Some(p)) => p,
+        _ => {
+            // Guard drops here → joins the thread before returning.
+            drop(guard);
+            return None;
+        }
+    };
+
     let addr = SocketAddr::new(std::net::IpAddr::V4(host_ip), port);
-    Some((addr, handle))
+    Some((addr, guard))
 }
 
 // ── listener-only tests (from #39) ─────────────────────────────────
@@ -196,8 +228,9 @@ async fn test_loopback_round_trip() {
     })
     .await;
 
-    // Always join the server thread, even if the client timed out.
-    server.join().expect("server panicked");
+    // JoinGuard ensures the thread is joined even if the assert
+    // below panics; explicit join() propagates server panics.
+    server.join();
     assert!(client_result.is_ok(), "test_loopback_round_trip timed out");
 }
 
@@ -237,7 +270,7 @@ async fn test_send_burst_past_cq_capacity() {
     })
     .await;
 
-    server.join().expect("server panicked");
+    server.join();
     assert!(
         client_result.is_ok(),
         "test_send_burst_past_cq_capacity timed out"
@@ -265,7 +298,7 @@ async fn test_accepted_connection_peer_addr() {
     })
     .await;
 
-    server.join().expect("server panicked");
+    server.join();
     assert!(
         client_result.is_ok(),
         "test_accepted_connection_peer_addr timed out"

--- a/ironsbe-transport-rdma/tests/loopback.rs
+++ b/ironsbe-transport-rdma/tests/loopback.rs
@@ -4,6 +4,10 @@
 //! runtime because both ends need separate epoll reactors to handle
 //! RDMA CM event channels on SoftRoCE.
 //!
+//! Every server thread wraps its work in `tokio::time::timeout` so
+//! it cannot hang if the client fails, and `server.join()` is called
+//! on every exit path (success, client timeout, panic).  See #50.
+//!
 //! When no RDMA device is available the tests print a message and
 //! return early, so `cargo test` on a host without RDMA succeeds.
 
@@ -34,14 +38,11 @@ fn try_bind_listener(addr: SocketAddr, max_msg: usize) -> Option<RdmaListener> {
 ///
 /// Respects `IRONSBE_LOOPBACK_IPV4` env var as an explicit override.
 /// Otherwise enumerates interfaces and prefers `eth*`/`en*`/`ib*`
-/// names over Docker/bridge/veth virtual interfaces, which would
-/// fail on multi-homed hosts even when SoftRoCE is correctly
-/// configured on the physical NIC.
+/// names over Docker/bridge/veth virtual interfaces.
 fn first_non_loopback_ipv4() -> Option<std::net::Ipv4Addr> {
     use std::ffi::CStr;
     use std::net::Ipv4Addr;
 
-    // Explicit override wins.
     if let Ok(val) = std::env::var("IRONSBE_LOOPBACK_IPV4")
         && let Ok(ip) = val.parse::<Ipv4Addr>()
         && !ip.is_loopback()
@@ -82,7 +83,6 @@ fn first_non_loopback_ipv4() -> Option<std::net::Ipv4Addr> {
         }
         libc::freeifaddrs(ifaddrs);
 
-        // Prefer physical NICs, then non-virtual, then anything.
         candidates
             .iter()
             .find(|(n, _)| is_preferred(n))
@@ -90,6 +90,55 @@ fn first_non_loopback_ipv4() -> Option<std::net::Ipv4Addr> {
             .or(candidates.first())
             .map(|(_, ip)| *ip)
     }
+}
+
+/// Spawns a server on a dedicated OS thread with its own tokio
+/// runtime.  The server binds to `0.0.0.0:0`, sends the bound port
+/// back via `port_tx`, then runs `server_body` inside a
+/// `timeout(TEST_TIMEOUT, ...)`.  If the timeout fires or the body
+/// panics, the thread exits cleanly — no indefinite hang.
+///
+/// Returns `(connect_addr, server_join_handle)`, or `None` if no
+/// RDMA device is available.
+fn spawn_server<F, Fut>(server_body: F) -> Option<(SocketAddr, std::thread::JoinHandle<()>)>
+where
+    F: FnOnce(RdmaListener) -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = ()>,
+{
+    let host_ip = first_non_loopback_ipv4()?;
+    let (port_tx, port_rx) = std::sync::mpsc::sync_channel::<Option<u16>>(1);
+
+    let handle = std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("server rt");
+        rt.block_on(async {
+            let bind: SocketAddr = "0.0.0.0:0".parse().expect("parse");
+            let listener = match RdmaListener::bind(bind, DEFAULT_MAX_MSG) {
+                Ok(l) => l,
+                Err(e) => {
+                    eprintln!("server bind: {e}");
+                    let _ = port_tx.send(None);
+                    return;
+                }
+            };
+            let _ = port_tx.send(Some(listener.local_addr().expect("la").port()));
+
+            // Bounded wait — the server thread cannot hang even if
+            // the client never connects.  See #50.
+            if timeout(TEST_TIMEOUT, server_body(listener)).await.is_err() {
+                eprintln!("server timed out (no client connected within {TEST_TIMEOUT:?})");
+            }
+        });
+    });
+
+    let port = port_rx
+        .recv_timeout(Duration::from_secs(5))
+        .ok()
+        .flatten()?;
+    let addr = SocketAddr::new(std::net::IpAddr::V4(host_ip), port);
+    Some((addr, handle))
 }
 
 // ── listener-only tests (from #39) ─────────────────────────────────
@@ -123,49 +172,21 @@ async fn test_accept_yields_to_runtime() {
     assert!(counter.load(Ordering::SeqCst) >= 10);
 }
 
-// ── loopback tests (from #48) ──────────────────────────────────────
+// ── loopback tests (from #48, server timeout from #50) ─────────────
 
 /// Full round-trip: client sends "hello", server echoes "world".
 #[tokio::test(flavor = "current_thread")]
 async fn test_loopback_round_trip() {
-    let host_ip = match first_non_loopback_ipv4() {
-        Some(ip) => ip,
-        None => {
-            eprintln!("no IPv4 — skip");
-            return;
-        }
-    };
-
-    let (port_tx, port_rx) = std::sync::mpsc::sync_channel::<Option<u16>>(1);
-    let server = std::thread::spawn(move || {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("server rt");
-        rt.block_on(async {
-            let bind: SocketAddr = "0.0.0.0:0".parse().expect("parse");
-            let mut listener = match RdmaListener::bind(bind, DEFAULT_MAX_MSG) {
-                Ok(l) => l,
-                Err(e) => {
-                    eprintln!("server bind: {e}");
-                    let _ = port_tx.send(None);
-                    return;
-                }
-            };
-            let _ = port_tx.send(Some(listener.local_addr().expect("la").port()));
-            let mut conn = listener.accept().await.expect("accept");
-            let msg = conn.recv().await.expect("recv");
-            assert_eq!(&msg.expect("some")[..], b"hello");
-            conn.send(b"world").await.expect("send");
-        });
-    });
-
-    let Some(port) = port_rx.recv_timeout(Duration::from_secs(5)).ok().flatten() else {
+    let Some((addr, server)) = spawn_server(|mut listener| async move {
+        let mut conn = listener.accept().await.expect("accept");
+        let msg = conn.recv().await.expect("recv");
+        assert_eq!(&msg.expect("some")[..], b"hello");
+        conn.send(b"world").await.expect("send");
+    }) else {
         return;
     };
-    let addr = SocketAddr::new(std::net::IpAddr::V4(host_ip), port);
 
-    let outer = timeout(TEST_TIMEOUT, async {
+    let client_result = timeout(TEST_TIMEOUT, async {
         let mut client = RdmaConnection::connect(addr, DEFAULT_MAX_MSG)
             .await
             .expect("connect");
@@ -174,70 +195,35 @@ async fn test_loopback_round_trip() {
         assert_eq!(&reply.expect("some")[..], b"world");
     })
     .await;
-    assert!(outer.is_ok(), "test_loopback_round_trip timed out");
+
+    // Always join the server thread, even if the client timed out.
     server.join().expect("server panicked");
+    assert!(client_result.is_ok(), "test_loopback_round_trip timed out");
 }
 
 /// > CQ_CAPACITY back-to-back sends.
 ///
-/// Currently `#[ignore]`-gated because the single `send_buf` design
-/// from #38 reuses the same memory for every SEND WR.  Back-to-back
-/// sends overwrite the buffer before the NIC reads the previous
-/// WR's data, corrupting in-flight frames.  The drain mechanism
-/// itself is correct (unit tests prove it), but the underlying
-/// buffer-reuse requires a multi-buffer refactor to actually
-/// support bursts.  Tracked separately.
+/// `#[ignore]`-gated: single `send_buf` design from #38 reuses the
+/// same memory for every SEND WR — needs multi-buffer refactor.
 #[tokio::test(flavor = "current_thread")]
 #[ignore = "single send_buf design from #38 — needs multi-buffer refactor for burst"]
 async fn test_send_burst_past_cq_capacity() {
-    let host_ip = match first_non_loopback_ipv4() {
-        Some(ip) => ip,
-        None => {
-            eprintln!("no IPv4 — skip");
-            return;
-        }
-    };
-
-    // Must be > CQ_CAPACITY (32) to exercise the drain path.
-    // Keep it moderate (48) because the drain_until_low_water
-    // yield loop needs the server to consume in parallel, and a
-    // very large burst on a single-threaded client can stall if
-    // the drain fills before completions arrive.
     const BURST: usize = 48;
-    let (port_tx, port_rx) = std::sync::mpsc::sync_channel::<Option<u16>>(1);
-    let server = std::thread::spawn(move || {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("server rt");
-        rt.block_on(async {
-            let bind: SocketAddr = "0.0.0.0:0".parse().expect("parse");
-            let mut listener = match RdmaListener::bind(bind, DEFAULT_MAX_MSG) {
-                Ok(l) => l,
-                Err(e) => {
-                    eprintln!("server bind: {e}");
-                    let _ = port_tx.send(None);
-                    return;
-                }
-            };
-            let _ = port_tx.send(Some(listener.local_addr().expect("la").port()));
-            let mut conn = listener.accept().await.expect("accept");
-            for i in 0..BURST {
-                let msg = conn
-                    .recv()
-                    .await
-                    .unwrap_or_else(|e| panic!("recv {i}: {e}"));
-                assert!(msg.is_some(), "None on recv {i}");
-            }
-        });
-    });
 
-    let Some(port) = port_rx.recv_timeout(Duration::from_secs(5)).ok().flatten() else {
+    let Some((addr, server)) = spawn_server(|mut listener| async move {
+        let mut conn = listener.accept().await.expect("accept");
+        for i in 0..BURST {
+            let msg = conn
+                .recv()
+                .await
+                .unwrap_or_else(|e| panic!("recv {i}: {e}"));
+            assert!(msg.is_some(), "None on recv {i}");
+        }
+    }) else {
         return;
     };
-    let addr = SocketAddr::new(std::net::IpAddr::V4(host_ip), port);
 
-    let outer = timeout(TEST_TIMEOUT, async {
+    let client_result = timeout(TEST_TIMEOUT, async {
         let mut client = RdmaConnection::connect(addr, DEFAULT_MAX_MSG)
             .await
             .expect("connect");
@@ -250,61 +236,38 @@ async fn test_send_burst_past_cq_capacity() {
         }
     })
     .await;
-    assert!(outer.is_ok(), "test_send_burst_past_cq_capacity timed out");
+
     server.join().expect("server panicked");
+    assert!(
+        client_result.is_ok(),
+        "test_send_burst_past_cq_capacity timed out"
+    );
 }
 
 /// `peer_addr()` on the server side must not be unspecified.
 #[tokio::test(flavor = "current_thread")]
 async fn test_accepted_connection_peer_addr() {
-    let host_ip = match first_non_loopback_ipv4() {
-        Some(ip) => ip,
-        None => {
-            eprintln!("no IPv4 — skip");
-            return;
-        }
-    };
-
-    let (port_tx, port_rx) = std::sync::mpsc::sync_channel::<Option<u16>>(1);
-    let server = std::thread::spawn(move || {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("server rt");
-        rt.block_on(async {
-            let bind: SocketAddr = "0.0.0.0:0".parse().expect("parse");
-            let mut listener = match RdmaListener::bind(bind, DEFAULT_MAX_MSG) {
-                Ok(l) => l,
-                Err(e) => {
-                    eprintln!("server bind: {e}");
-                    let _ = port_tx.send(None);
-                    return;
-                }
-            };
-            let _ = port_tx.send(Some(listener.local_addr().expect("la").port()));
-            let conn = listener.accept().await.expect("accept");
-            let peer = conn.peer_addr().expect("peer_addr");
-            assert_ne!(peer.port(), 0);
-            assert!(!peer.ip().is_unspecified(), "peer IP unspecified: {peer}");
-            eprintln!("[peer_addr] {peer}");
-        });
-    });
-
-    let Some(port) = port_rx.recv_timeout(Duration::from_secs(5)).ok().flatten() else {
+    let Some((addr, server)) = spawn_server(|mut listener| async move {
+        let conn = listener.accept().await.expect("accept");
+        let peer = conn.peer_addr().expect("peer_addr");
+        assert_ne!(peer.port(), 0);
+        assert!(!peer.ip().is_unspecified(), "peer IP unspecified: {peer}");
+        eprintln!("[peer_addr] {peer}");
+    }) else {
         return;
     };
-    let addr = SocketAddr::new(std::net::IpAddr::V4(host_ip), port);
 
-    let outer = timeout(TEST_TIMEOUT, async {
+    let client_result = timeout(TEST_TIMEOUT, async {
         let _client = RdmaConnection::connect(addr, DEFAULT_MAX_MSG)
             .await
             .expect("connect");
         tokio::time::sleep(Duration::from_millis(200)).await;
     })
     .await;
+
+    server.join().expect("server panicked");
     assert!(
-        outer.is_ok(),
+        client_result.is_ok(),
         "test_accepted_connection_peer_addr timed out"
     );
-    server.join().expect("server panicked");
 }


### PR DESCRIPTION
Closes #50, closes #51.

## Summary

Two small refactors in `ironsbe-transport-rdma`, bundled because they touch separate areas of the same crate with no overlap.

### #50 — Server test timeouts

All loopback integration tests in `tests/loopback.rs` now use a shared `spawn_server` helper that:
- Wraps the server's entire `block_on` future in `tokio::time::timeout(TEST_TIMEOUT, ...)`, so the server thread exits cleanly if the client never connects.
- `server.join()` is called AFTER the client result is captured (not before the assert), so the server thread is always joined on every exit path — success, client timeout, or panic.

This eliminates the hang risk where a failed client left the server thread blocked in `accept()` indefinitely.

### #51 — Rename `RdmaConfig::bind_addr` → `addr`

`RdmaConfig::bind_addr` was documented as the listener bind address but also used as the client connect target. Renamed to `addr` with updated doc:

> Target address — the bind address for listeners, the remote endpoint for client connections.

Updated: field name, `new()` parameter, `From<SocketAddr>` impl, `bind_with` and `connect_with` call sites.

## Test plan

- [x] `cargo clippy -p ironsbe-transport-rdma --all-targets -- -D warnings` (Linux) — clean
- [x] `cargo test -p ironsbe-transport-rdma` (Linux/SoftRoCE) — 12 passing, 1 ignored
- [x] `make lint-fix` + `make pre-push` (macOS) — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (macOS) — clean
- [ ] CI green