### PR TITLE
feat(server): ServerHandle::send_to for server-initiated unicast push

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,17 +61,17 @@ ironsbe-bench = { path = "ironsbe-bench", version = "0.3.0" }
 thiserror = "2.0"
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-bytes = { version = "1.11", features = ["serde"] }
+bytes = { version = "1.12", features = ["serde"] }
 parking_lot = "0.12"
 crossbeam-channel = "0.5"
 crossbeam-queue = "0.3"
-tokio = { version = "1.51", features = ["full"] }
+tokio = { version = "1.52", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec", "rt"] }
-socket2 = "0.5"
+socket2 = "0.6"
 tokio-uring = "0.5"
-smoltcp = { version = "0.12", default-features = false, features = ["std", "medium-ethernet", "proto-ipv4", "socket-tcp"] }
-xsk-rs = "0.6"
-etherparse = "0.18"
+smoltcp = { version = "0.13", default-features = false, features = ["std", "medium-ethernet", "proto-ipv4", "socket-tcp"] }
+xsk-rs = "0.8"
+etherparse = "0.20"
 futures = "0.3"
 async-trait = "0.1"
 tracing = "0.1"
@@ -79,12 +79,12 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 num-traits = "0.2"
 num-derive = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
-quick-xml = "0.39"
+quick-xml = "0.40"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full", "parsing"] }
 rtrb = "0.3"
-lru = "0.16"
+lru = "0.18"
 memmap2 = "0.9"
 criterion = { version = "0.8", features = ["html_reports"] }
 hdrhistogram = "7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ ironsbe-codegen = { path = "ironsbe-codegen", version = "0.3.0" }
 ironsbe-derive = { path = "ironsbe-derive", version = "0.3.0" }
 ironsbe-channel = { path = "ironsbe-channel", version = "0.3.0" }
 ironsbe-transport = { path = "ironsbe-transport", version = "0.3.0" }
-ironsbe-server = { path = "ironsbe-server", version = "0.3.0" }
+ironsbe-server = { path = "ironsbe-server", version = "0.4.0" }
 ironsbe-client = { path = "ironsbe-client", version = "0.3.0" }
 ironsbe-marketdata = { path = "ironsbe-marketdata", version = "0.3.0" }
 ironsbe-bench = { path = "ironsbe-bench", version = "0.3.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ default-members = [
 ]
 
 [workspace.package]
+version = "0.4.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 license = "MIT"
@@ -45,17 +46,17 @@ categories = ["finance", "encoding", "network-programming"]
 
 [workspace.dependencies]
 # Internal crates
-ironsbe = { path = "ironsbe", version = "0.3.0" }
-ironsbe-core = { path = "ironsbe-core", version = "0.3.0" }
-ironsbe-schema = { path = "ironsbe-schema", version = "0.3.0" }
-ironsbe-codegen = { path = "ironsbe-codegen", version = "0.3.0" }
-ironsbe-derive = { path = "ironsbe-derive", version = "0.3.0" }
-ironsbe-channel = { path = "ironsbe-channel", version = "0.3.0" }
-ironsbe-transport = { path = "ironsbe-transport", version = "0.3.0" }
+ironsbe = { path = "ironsbe", version = "0.4.0" }
+ironsbe-core = { path = "ironsbe-core", version = "0.4.0" }
+ironsbe-schema = { path = "ironsbe-schema", version = "0.4.0" }
+ironsbe-codegen = { path = "ironsbe-codegen", version = "0.4.0" }
+ironsbe-derive = { path = "ironsbe-derive", version = "0.4.0" }
+ironsbe-channel = { path = "ironsbe-channel", version = "0.4.0" }
+ironsbe-transport = { path = "ironsbe-transport", version = "0.4.0" }
 ironsbe-server = { path = "ironsbe-server", version = "0.4.0" }
-ironsbe-client = { path = "ironsbe-client", version = "0.3.0" }
-ironsbe-marketdata = { path = "ironsbe-marketdata", version = "0.3.0" }
-ironsbe-bench = { path = "ironsbe-bench", version = "0.3.0" }
+ironsbe-client = { path = "ironsbe-client", version = "0.4.0" }
+ironsbe-marketdata = { path = "ironsbe-marketdata", version = "0.4.0" }
+ironsbe-bench = { path = "ironsbe-bench", version = "0.4.0" }
 
 # External dependencies - Latest stable versions as of Jan 2025
 thiserror = "2.0"

--- a/ironsbe-bench/Cargo.toml
+++ b/ironsbe-bench/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ironsbe-bench"
 description = "Benchmarking suite for IronSBE"
-version = "0.3.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/ironsbe-channel/Cargo.toml
+++ b/ironsbe-channel/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ironsbe-channel"
 description = "High-performance channel abstractions for IronSBE messaging"
-version = "0.3.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/ironsbe-client/Cargo.toml
+++ b/ironsbe-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ironsbe-client"
 description = "Client-side engine for IronSBE messaging"
-version = "0.3.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/ironsbe-codegen/Cargo.toml
+++ b/ironsbe-codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ironsbe-codegen"
 description = "Code generation from SBE XML schemas for IronSBE"
-version = "0.3.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/ironsbe-core/Cargo.toml
+++ b/ironsbe-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ironsbe-core"
 description = "Core types and traits for IronSBE - zero-copy SBE encoding/decoding"
-version = "0.3.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/ironsbe-derive/Cargo.toml
+++ b/ironsbe-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ironsbe-derive"
 description = "Procedural macros for IronSBE message definitions"
-version = "0.3.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/ironsbe-marketdata/Cargo.toml
+++ b/ironsbe-marketdata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ironsbe-marketdata"
 description = "Market data handling patterns for IronSBE - order books, recovery, arbitration"
-version = "0.3.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/ironsbe-schema/Cargo.toml
+++ b/ironsbe-schema/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ironsbe-schema"
 description = "SBE XML schema parser and type definitions for IronSBE"
-version = "0.3.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/ironsbe-server/CHANGELOG.md
+++ b/ironsbe-server/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog — ironsbe-server
+
+## 0.3.1
+
+### Added
+- `ServerHandle::send_to(session_id, message)` — server-initiated **unicast**
+  push to a single session, complementing `broadcast` (all sessions). Backed by a
+  new `ServerCommand::SendTo(u64, Vec<u8>)` handled in the run loop, which resolves
+  the target in the live session-sender registry and opportunistically reaps a
+  closed channel (mirroring `Broadcast`). A missing session id is a benign no-op.
+
+  Enables consumers to drive subscription-gated server push (e.g. account-manager's
+  live `MmEligibilityChanged` stream) without broadcasting to every session.

--- a/ironsbe-server/CHANGELOG.md
+++ b/ironsbe-server/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog — ironsbe-server
 
-## 0.3.1
+## 0.4.0
 
 ### Added
 - `ServerHandle::send_to(session_id, message)` — server-initiated **unicast**
@@ -11,3 +11,8 @@
 
   Enables consumers to drive subscription-gated server push (e.g. account-manager's
   live `MmEligibilityChanged` stream) without broadcasting to every session.
+
+### Changed (breaking)
+- `ServerCommand` is now `#[non_exhaustive]`. Downstream code matching on it
+  must add a wildcard arm. This makes future command additions non-breaking
+  (minor releases). Minor bump under 0.x semver reflects the break.

--- a/ironsbe-server/Cargo.toml
+++ b/ironsbe-server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ironsbe-server"
 description = "Server-side engine for IronSBE messaging"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/ironsbe-server/Cargo.toml
+++ b/ironsbe-server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ironsbe-server"
 description = "Server-side engine for IronSBE messaging"
-version = "0.4.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/ironsbe-server/Cargo.toml
+++ b/ironsbe-server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ironsbe-server"
 description = "Server-side engine for IronSBE messaging"
-version = "0.3.1"
+version = "0.4.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/ironsbe-server/src/builder.rs
+++ b/ironsbe-server/src/builder.rs
@@ -490,7 +490,11 @@ impl ServerHandle {
 }
 
 /// Commands that can be sent to the server.
+///
+/// Marked `#[non_exhaustive]`: new control commands may be added in minor
+/// releases, so downstream consumers must include a wildcard arm when matching.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum ServerCommand {
     /// Shutdown the server.
     Shutdown,

--- a/ironsbe-server/src/builder.rs
+++ b/ironsbe-server/src/builder.rs
@@ -407,6 +407,19 @@ where
                     .retain(|_, sender| sender.send(message.clone()).is_ok());
                 false
             }
+            ServerCommand::SendTo(session_id, message) => {
+                // Push the bytes to a single live session (server-initiated
+                // unicast). A missing entry (never-connected or already-gone
+                // session) is a benign no-op; a closed channel is dropped from
+                // the registry, mirroring `Broadcast`'s opportunistic cleanup.
+                let mut senders = self.session_senders.write();
+                if let Some(sender) = senders.get(&session_id)
+                    && sender.send(message).is_err()
+                {
+                    senders.remove(&session_id);
+                }
+                false
+            }
         }
     }
 }
@@ -456,6 +469,20 @@ impl ServerHandle {
         self.cmd_notify.notify_one();
     }
 
+    /// Sends a message to a single session by id (server-initiated push).
+    ///
+    /// Unlike [`Self::broadcast`], only the session identified by `session_id`
+    /// receives the bytes. A non-existent or already-closed session is a benign
+    /// no-op (the stale entry is reaped on the next attempt). Non-blocking: the
+    /// command is queued on the control channel and the run loop performs the
+    /// actual send.
+    pub fn send_to(&self, session_id: u64, message: Vec<u8>) {
+        let _ = self
+            .cmd_tx
+            .try_send(ServerCommand::SendTo(session_id, message));
+        self.cmd_notify.notify_one();
+    }
+
     /// Polls for server events.
     pub fn poll_events(&self) -> impl Iterator<Item = ServerEvent> + '_ {
         std::iter::from_fn(|| self.event_rx.try_recv())
@@ -471,6 +498,8 @@ pub enum ServerCommand {
     CloseSession(u64),
     /// Broadcast a message to all sessions.
     Broadcast(Vec<u8>),
+    /// Send a message to a single session by id (server-initiated push).
+    SendTo(u64, Vec<u8>),
 }
 
 /// Events emitted by the server.
@@ -891,6 +920,59 @@ mod tests {
         // Both entries must still be live — their channels are
         // healthy.
         assert_eq!(server.session_senders.read().len(), 2);
+    }
+
+    /// `SendTo` must push the payload to only the targeted session, leaving
+    /// every other session's channel untouched.
+    #[tokio::test]
+    async fn test_send_to_handler_reaches_only_target_session() {
+        let (mut server, _handle) = DefaultBuilder::<TestHandler>::new()
+            .handler(TestHandler)
+            .build();
+
+        let (tx1, mut rx1) = tokio_mpsc::unbounded_channel::<Vec<u8>>();
+        let (tx2, mut rx2) = tokio_mpsc::unbounded_channel::<Vec<u8>>();
+        {
+            let mut senders = server.session_senders.write();
+            senders.insert(1, tx1);
+            senders.insert(2, tx2);
+        }
+
+        let payload = b"unicast-to-2".to_vec();
+        let exited = server
+            .handle_command(ServerCommand::SendTo(2, payload.clone()))
+            .await;
+
+        assert!(!exited);
+        match rx2.try_recv() {
+            Ok(bytes) => assert_eq!(bytes, payload),
+            other => panic!("target session 2 did not receive the unicast: {other:?}"),
+        }
+        assert!(
+            rx1.try_recv().is_err(),
+            "non-target session 1 must not receive the unicast"
+        );
+        // Both sessions remain live.
+        assert_eq!(server.session_senders.read().len(), 2);
+    }
+
+    /// `SendTo` for a missing session id is a benign no-op (no panic, no change
+    /// to the registry).
+    #[tokio::test]
+    async fn test_send_to_handler_missing_session_is_noop() {
+        let (mut server, _handle) = DefaultBuilder::<TestHandler>::new()
+            .handler(TestHandler)
+            .build();
+
+        let (tx1, _rx1) = tokio_mpsc::unbounded_channel::<Vec<u8>>();
+        server.session_senders.write().insert(1, tx1);
+
+        let exited = server
+            .handle_command(ServerCommand::SendTo(99, b"nobody-home".to_vec()))
+            .await;
+
+        assert!(!exited);
+        assert_eq!(server.session_senders.read().len(), 1);
     }
 
     /// `Broadcast` must drop entries whose receiver has already been

--- a/ironsbe-server/src/local_builder.rs
+++ b/ironsbe-server/src/local_builder.rs
@@ -263,6 +263,10 @@ where
                 false
             }
             ServerCommand::Broadcast(_message) => false,
+            // The single-threaded LocalServer does not track a session-sender
+            // registry, so server-initiated push is a no-op here (as Broadcast
+            // is); the multi-threaded `Server` implements both. See builder.rs.
+            ServerCommand::SendTo(_session_id, _message) => false,
         }
     }
 }

--- a/ironsbe-transport-dpdk/Cargo.toml
+++ b/ironsbe-transport-dpdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ironsbe-transport-dpdk"
 description = "DPDK transport backend for IronSBE (Linux-only, opt-in)"
-version = "0.3.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/ironsbe-transport-rdma/Cargo.toml
+++ b/ironsbe-transport-rdma/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ironsbe-transport-rdma"
 description = "RDMA/ibverbs transport backend for IronSBE (Linux-only, opt-in)"
-version = "0.3.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/ironsbe-transport-rdma/src/listener.rs
+++ b/ironsbe-transport-rdma/src/listener.rs
@@ -301,7 +301,12 @@ pub(crate) async fn wait_for_cm_event(
         let event_type = unsafe { (*event).event };
         let event_status = unsafe { (*event).status };
         let id = unsafe { (*event).id };
-        tracing::debug!(expected, event_type, event_status, "wait_for_cm_event: got event");
+        tracing::debug!(
+            expected,
+            event_type,
+            event_status,
+            "wait_for_cm_event: got event"
+        );
         unsafe { ffi::rdma_ack_cm_event(event) };
 
         if event_type == expected {

--- a/ironsbe-transport/Cargo.toml
+++ b/ironsbe-transport/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ironsbe-transport"
 description = "Network transport layer for IronSBE - TCP, UDP, and IPC"
-version = "0.3.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/ironsbe/Cargo.toml
+++ b/ironsbe/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ironsbe"
 description = "High-performance SBE (Simple Binary Encoding) server/client for Rust"
-version = "0.3.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
Add ServerCommand::SendTo(session_id, bytes) + ServerHandle::send_to, handled in the multi-threaded Server run loop (resolve target in the live session-sender registry, reap a closed channel like Broadcast). LocalServer treats it as a no-op. Enables subscription-gated push (e.g. account-manager MmEligibilityChanged) without broadcasting to all sessions. Bump ironsbe-server 0.3.0 -> 0.3.1.