### PR TITLE
fix(server): instrument SBE session tasks instead of Span::enter() across .await (#54)

### DIFF
--- a/ironsbe-server/src/builder.rs
+++ b/ironsbe-server/src/builder.rs
@@ -13,6 +13,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::{Notify, mpsc as tokio_mpsc};
 use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
 
 /// Shared per-session outbound-sender registry.  Populated in
 /// [`Server::handle_connection`], drained in
@@ -340,34 +341,41 @@ where
         handler.on_session_start(session_id);
         let _ = event_tx.try_send(ServerEvent::SessionCreated(session_id, addr));
 
-        // Spawn connection handler task.  The span gives every log
-        // line inside the session the `sbe_session{session_id=N}:`
-        // prefix so operators can correlate messages per peer.
+        // Spawn connection handler task. The `sbe_session` span is attached to
+        // the future via `Instrument::instrument` instead of a `Span::enter()`
+        // guard held across `.await`: on the multi-threaded runtime the future
+        // can resume on a different worker thread, and a held guard would drive
+        // tracing-subscriber's per-thread span ref-counting across threads,
+        // racing into a `clone_span` panic that silently kills the accept loop
+        // (issue #54). The span still gives every log line inside the session
+        // the `sbe_session{session_id=N}:` prefix for per-peer correlation.
         let span = tracing::info_span!("sbe_session", session_id, %addr);
-        tokio::spawn(async move {
-            let _guard = span.enter();
-            tracing::info!("connected");
+        tokio::spawn(
+            async move {
+                tracing::info!("connected");
 
-            if let Err(e) = handle_session(
-                session_id,
-                conn,
-                handler.as_ref(),
-                session_token,
-                out_tx,
-                out_rx,
-                senders,
-            )
-            .await
-            {
-                tracing::error!(error = %e, "session error");
+                if let Err(e) = handle_session(
+                    session_id,
+                    conn,
+                    handler.as_ref(),
+                    session_token,
+                    out_tx,
+                    out_rx,
+                    senders,
+                )
+                .await
+                {
+                    tracing::error!(error = %e, "session error");
+                }
+
+                tracing::info!("disconnected");
+                handler.on_session_end(session_id);
+                let _ = event_tx.try_send(ServerEvent::SessionClosed(session_id));
+                let _ = cmd_tx.try_send(ServerCommand::CloseSession(session_id));
+                cmd_notify.notify_one();
             }
-
-            tracing::info!("disconnected");
-            handler.on_session_end(session_id);
-            let _ = event_tx.try_send(ServerEvent::SessionClosed(session_id));
-            let _ = cmd_tx.try_send(ServerCommand::CloseSession(session_id));
-            cmd_notify.notify_one();
-        });
+            .instrument(span),
+        );
     }
 
     async fn handle_command(&mut self, cmd: ServerCommand) -> bool {

--- a/ironsbe-server/src/local_builder.rs
+++ b/ironsbe-server/src/local_builder.rs
@@ -23,6 +23,7 @@ use std::net::SocketAddr;
 use std::rc::Rc;
 use std::sync::Arc;
 use tokio::sync::{Notify, mpsc as tokio_mpsc};
+use tracing::Instrument;
 
 use crate::builder::{ServerCommand, ServerEvent, ServerHandle};
 
@@ -234,22 +235,27 @@ where
         let _ = event_tx.try_send(ServerEvent::SessionCreated(session_id, addr));
 
         // `spawn_local` keeps the future on the current single-threaded
-        // runtime, satisfying the `!Send` connection bound.  The span
-        // gives every log line inside the session the
-        // `sbe_session{session_id=N}:` prefix.
+        // runtime, satisfying the `!Send` connection bound. The `sbe_session`
+        // span is attached to the future via `Instrument::instrument` rather
+        // than a `Span::enter()` guard held across `.await`: even though
+        // `spawn_local` never migrates threads, holding a guard across `.await`
+        // is the same anti-pattern fixed in the multi-threaded path (issue #54).
+        // The span still prefixes every log line with `sbe_session{session_id=N}:`.
         let span = tracing::info_span!("sbe_session", session_id, %addr);
-        tokio::task::spawn_local(async move {
-            let _guard = span.enter();
-            tracing::info!("connected");
-            if let Err(e) = handle_local_session(session_id, conn, handler.as_ref()).await {
-                tracing::error!(error = %e, "session error");
+        tokio::task::spawn_local(
+            async move {
+                tracing::info!("connected");
+                if let Err(e) = handle_local_session(session_id, conn, handler.as_ref()).await {
+                    tracing::error!(error = %e, "session error");
+                }
+                tracing::info!("disconnected");
+                handler.on_session_end(session_id);
+                let _ = event_tx.try_send(ServerEvent::SessionClosed(session_id));
+                let _ = cmd_tx.try_send(ServerCommand::CloseSession(session_id));
+                cmd_notify.notify_one();
             }
-            tracing::info!("disconnected");
-            handler.on_session_end(session_id);
-            let _ = event_tx.try_send(ServerEvent::SessionClosed(session_id));
-            let _ = cmd_tx.try_send(ServerCommand::CloseSession(session_id));
-            cmd_notify.notify_one();
-        });
+            .instrument(span),
+        );
     }
 
     async fn handle_command(&mut self, cmd: ServerCommand) -> bool {

--- a/ironsbe-server/tests/no_enter_guard.rs
+++ b/ironsbe-server/tests/no_enter_guard.rs
@@ -1,0 +1,65 @@
+//! Structural guard for issue #19.
+//!
+//! Holding a `Span::enter()` guard across `.await` on the multi-threaded runtime
+//! races tracing-subscriber's per-thread span ref-counting and panics a worker in
+//! `clone_span`, silently killing the SBE accept loop. The crate attaches spans
+//! with `#[tracing::instrument]` / `Instrument::instrument` instead. This test
+//! fails if a bare `.enter()` reappears anywhere under `src/`, so the anti-pattern
+//! cannot be reintroduced unnoticed.
+//!
+//! Escape hatch: a line that genuinely needs a synchronous span guard (one that is
+//! never held across `.await`) can opt out by appending `// allow: span-enter`.
+
+use std::path::{Path, PathBuf};
+
+/// Recursively collects every `.rs` file under `dir`.
+fn rust_files(dir: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) => panic!("failed to read {}: {e}", dir.display()),
+    };
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(e) => panic!("failed to read dir entry under {}: {e}", dir.display()),
+        };
+        let path = entry.path();
+        if path.is_dir() {
+            files.extend(rust_files(&path));
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            files.push(path);
+        }
+    }
+    files
+}
+
+#[test]
+fn no_span_enter_guard_in_src() {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut offenders = Vec::new();
+
+    for file in rust_files(&src) {
+        let contents = match std::fs::read_to_string(&file) {
+            Ok(contents) => contents,
+            Err(e) => panic!("failed to read {}: {e}", file.display()),
+        };
+        for (index, line) in contents.lines().enumerate() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("//") || line.contains("// allow: span-enter") {
+                continue;
+            }
+            if line.contains(".enter()") {
+                offenders.push(format!("{}:{}", file.display(), index + 1));
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "found `.enter()` span guard(s) under src/ (issue #19 anti-pattern; use \
+         `#[tracing::instrument]` / `Instrument::instrument`, or append \
+         `// allow: span-enter` if the guard is never held across `.await`):\n{}",
+        offenders.join("\n")
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the SBE listener dying under connection churn on the multi-threaded server (issue #54).

The per-session task held a `Span::enter()` guard across `.await`. On the multi-threaded
runtime the session future can resume on a different worker thread while the guard is still
held, which drives `tracing-subscriber`'s per-thread span ref-counting across threads and,
under load, races into a `clone_span` panic:

```
thread 'tokio-rt-worker' panicked at tracing-subscriber/src/registry/sharded.rs:
  assert_ne!(refs, 0, "tried to clone a span that already closed", id)
```

The panicked worker is lost and the accept loop stops accepting SBE connections for the rest
of the process — the host stays healthy, only the SBE listener is dead, so new clients hit
`request timed out`.

## Fix

Attach the `sbe_session` span to the spawned future via `tracing::Instrument::instrument`
instead of holding an `enter()` guard across `.await`. The span is bound to the future, so it
travels correctly across thread migrations.

- `ironsbe-server/src/builder.rs` — multi-threaded `tokio::spawn` path (the one that panics).
- `ironsbe-server/src/local_builder.rs` — `spawn_local` path. It can't hit the cross-thread
  race (single-threaded), but the `enter()`-across-`.await` pattern is incorrect tracing usage
  and is fixed for consistency.

Span fields and the `sbe_session{session_id=N}:` log prefix are preserved — no behavioural
change other than the panic going away.

## Regression guard

`ironsbe-server/tests/no_enter_guard.rs` — a structural test that scans every `.rs` under
`src/` and fails if a bare `.enter()` reappears, so the anti-pattern can't be reintroduced
unnoticed. A line that genuinely needs a synchronous (never-held-across-`.await`) guard can
opt out with `// allow: span-enter`.

## Verification

- `cargo test -p ironsbe-server` — all pass, including the new `no_span_enter_guard_in_src`.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (excluding the
  `rdma`/`dpdk` transport backends, which require system libs unavailable on the build host).
- `cargo fmt --check` — clean.

Closes #54
