### PR TITLE
build(deps): bump quick-xml 0.40 -> 0.41 (RUSTSEC-2026-0194/0195)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 num-traits = "0.2"
 num-derive = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
-quick-xml = "0.40"
+quick-xml = "0.41"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full", "parsing"] }


### PR DESCRIPTION
## Summary

Bumps `quick-xml` from `0.40` to `0.41` to clear two advisories published 2026-07-03, both patched only in `>= 0.41.0`:

- **RUSTSEC-2026-0194** — quadratic run time when checking a start tag for duplicate attribute names.
- **RUSTSEC-2026-0195** — unbounded namespace-declaration allocation in `NsReader` (memory-exhaustion DoS).

`main` was on `quick-xml = "0.40"`, which is still within the affected range.

## Changes

- `Cargo.toml` (workspace root) — `quick-xml = "0.40"` → `"0.41"`. Single line; `Cargo.lock` is gitignored, so consumers resolve `0.41.x` from the requirement.

## Verification

`ironsbe-schema` is the only crate using `quick-xml` (`Reader`, `Event`, `BytesStart`, `quick_xml::Error` in `parser.rs` / `error.rs`). The API is unchanged across 0.40 → 0.41 — no source edits were needed.

- `cargo build --workspace` (excluding the `ironsbe-transport-dpdk` / `-rdma` crates, which fail on missing native DPDK/RDMA libs on macOS — unrelated to this change and pre-existing) — clean.
- `cargo test -p ironsbe-schema` — 24 passed.
- `cargo test -p ironsbe-codegen` — 58 passed (no generated-SBE-output drift).
- Full workspace test run (excluding the native-dep transports) — all green, 0 failures.
- `cargo fmt --all --check` and `cargo clippy` on the affected crates — clean.

## Context

Downstream Layer-V repos pull `quick-xml` transitively as a build-dependency of `ironsbe-codegen`, which reddened their `cargo audit` / `cargo deny` Security Audit across the fleet. Filed as #57. Consumers are on a temporary ignore-list and will drop it and bump `ironsbe-*` once a patched release is published to crates.io.

Closes #57
